### PR TITLE
back porting improvements to the eigenda client. 

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -32,6 +32,7 @@ secrecy = "0.8.0"
 byteorder = "1.5.0"
 url = "2.5.2"
 tempfile = "3.0.2"
+hex-literal = "0.3"
 
 [dev-dependencies]
 serial_test = "3.1.1"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,6 +31,7 @@ hex = "0.4"
 secrecy = "0.8.0"
 byteorder = "1.5.0"
 url = "2.5.2"
+tempfile = "3.0.2"
 
 [dev-dependencies]
 serial_test = "3.1.1"

--- a/src/blob_info.rs
+++ b/src/blob_info.rs
@@ -28,16 +28,16 @@ impl From<DisperserG1Commitment> for G1Commitment {
 }
 
 /// Internal of BlobInfo
-/// Contains data related to the blob quorums
-/// quorum_number: The ID of the quorum.
-/// adversary_threshold_percentage: The max percentage of stake within the quorum that can be held by or delegated to adversarial operators.
-/// confirmation_threshold_percentage: the min percentage of stake that must attest in order to consider the dispersal is successful.    
-/// chunk_length: The length of each chunk.    
+/// Contains data related to the blob quorums  
 #[derive(Debug, PartialEq, Clone)]
 pub struct BlobQuorumParam {
+    /// The ID of the quorum.
     pub quorum_number: u32,
+    /// The max percentage of stake within the quorum that can be held by or delegated to adversarial operators.
     pub adversary_threshold_percentage: u32,
+    /// The min percentage of stake that must attest in order to consider the dispersal is successful.    
     pub confirmation_threshold_percentage: u32,
+    /// The length of each chunk.    
     pub chunk_length: u32,
 }
 

--- a/src/blob_info.rs
+++ b/src/blob_info.rs
@@ -28,14 +28,15 @@ impl From<DisperserG1Commitment> for G1Commitment {
 }
 
 /// Internal of BlobInfo
-/// Contains data related to the blob quorums  
+/// (aliased as EigenDACert in the EigenDA proxy)
+/// Contains data related to the blob quorums
 #[derive(Debug, PartialEq, Clone)]
 pub struct BlobQuorumParam {
     /// The ID of the quorum.
     pub quorum_number: u32,
     /// The max percentage of stake within the quorum that can be held by or delegated to adversarial operators.
     pub adversary_threshold_percentage: u32,
-    /// The min percentage of stake that must attest in order to consider the dispersal successful.    
+    /// The min percentage of stake that must attest in order to consider the dispersal successful.
     pub confirmation_threshold_percentage: u32,
     /// The length of each chunk in bn254 field elements (32 bytes each).
     pub chunk_length: u32,

--- a/src/blob_info.rs
+++ b/src/blob_info.rs
@@ -30,11 +30,11 @@ impl From<DisperserG1Commitment> for G1Commitment {
 /// Internal of BlobInfo
 /// Contains data related to the blob quorums
 #[derive(Debug, PartialEq, Clone)]
-pub(crate) struct BlobQuorumParam {
-    pub(crate) quorum_number: u32,
-    pub(crate) adversary_threshold_percentage: u32,
-    pub(crate) confirmation_threshold_percentage: u32,
-    pub(crate) chunk_length: u32,
+pub struct BlobQuorumParam {
+    pub quorum_number: u32,
+    pub adversary_threshold_percentage: u32,
+    pub confirmation_threshold_percentage: u32,
+    pub chunk_length: u32,
 }
 
 impl From<DisperserBlobQuorumParam> for BlobQuorumParam {

--- a/src/blob_info.rs
+++ b/src/blob_info.rs
@@ -29,8 +29,10 @@ impl From<DisperserG1Commitment> for G1Commitment {
 
 /// Internal of BlobInfo
 /// Contains data related to the blob quorums
-/// It is public since it is used by WrongQuorumParams Error
-/// This are verified against the contracts before confirming the blob
+/// quorum_number: The ID of the quorum.
+/// adversary_threshold_percentage: The max percentage of stake within the quorum that can be held by or delegated to adversarial operators.
+/// confirmation_threshold_percentage: the min percentage of stake that must attest in order to consider the dispersal is successful.    
+/// chunk_length: The length of each chunk.    
 #[derive(Debug, PartialEq, Clone)]
 pub struct BlobQuorumParam {
     pub quorum_number: u32,

--- a/src/blob_info.rs
+++ b/src/blob_info.rs
@@ -10,7 +10,7 @@ use super::{
     },
 };
 
-/// Internal of BlobInfo
+/// Internal of BlobInfo (aka EigenDACertV1)
 /// Contains the KZG Commitment
 #[derive(Debug, PartialEq, Clone)]
 pub(crate) struct G1Commitment {
@@ -27,8 +27,7 @@ impl From<DisperserG1Commitment> for G1Commitment {
     }
 }
 
-/// Internal of BlobInfo
-/// (aliased as EigenDACert in the EigenDA proxy)
+/// Internal of BlobInfo (aka EigenDACertV1)
 /// Contains data related to the blob quorums
 #[derive(Debug, PartialEq, Clone)]
 pub struct BlobQuorumParam {
@@ -53,7 +52,7 @@ impl From<DisperserBlobQuorumParam> for BlobQuorumParam {
     }
 }
 
-/// Internal of BlobInfo
+/// Internal of BlobInfo (aka EigenDACertV1)
 /// Contains the blob header data
 #[derive(Debug, PartialEq, Clone)]
 pub(crate) struct BlobHeader {
@@ -82,7 +81,7 @@ impl TryFrom<DisperserBlobHeader> for BlobHeader {
     }
 }
 
-/// Internal of BlobInfo
+/// Internal of BlobInfo (aka EigenDACertV1)
 #[derive(Debug, PartialEq, Clone)]
 pub(crate) struct BatchHeader {
     pub(crate) batch_root: Vec<u8>,
@@ -102,7 +101,7 @@ impl From<DisperserBatchHeader> for BatchHeader {
     }
 }
 
-/// Internal of BlobInfo
+/// Internal of BlobInfo (aka EigenDACertV1)
 #[derive(Debug, PartialEq, Clone)]
 pub(crate) struct BatchMetadata {
     pub(crate) batch_header: BatchHeader,
@@ -129,7 +128,7 @@ impl TryFrom<DisperserBatchMetadata> for BatchMetadata {
     }
 }
 
-/// Internal of BlobInfo
+/// Internal of BlobInfo (aka EigenDACertV1)
 #[derive(Debug, PartialEq, Clone)]
 pub(crate) struct BlobVerificationProof {
     pub(crate) batch_id: u32,
@@ -154,7 +153,7 @@ impl TryFrom<DisperserBlobVerificationProof> for BlobVerificationProof {
     }
 }
 
-/// Data returned by the disperser when a blob is dispersed
+/// Data returned by the disperser when a blob is dispersed (aka EigenDACertV1)
 #[derive(Debug, PartialEq, Clone)]
 pub(crate) struct BlobInfo {
     pub(crate) blob_header: BlobHeader,

--- a/src/blob_info.rs
+++ b/src/blob_info.rs
@@ -29,6 +29,8 @@ impl From<DisperserG1Commitment> for G1Commitment {
 
 /// Internal of BlobInfo
 /// Contains data related to the blob quorums
+/// It is public since it is used by WrongQuorumParams Error
+/// This are verified against the contracts before confirming the blob
 #[derive(Debug, PartialEq, Clone)]
 pub struct BlobQuorumParam {
     pub quorum_number: u32,

--- a/src/blob_info.rs
+++ b/src/blob_info.rs
@@ -35,9 +35,9 @@ pub struct BlobQuorumParam {
     pub quorum_number: u32,
     /// The max percentage of stake within the quorum that can be held by or delegated to adversarial operators.
     pub adversary_threshold_percentage: u32,
-    /// The min percentage of stake that must attest in order to consider the dispersal is successful.    
+    /// The min percentage of stake that must attest in order to consider the dispersal successful.    
     pub confirmation_threshold_percentage: u32,
-    /// The length of each chunk.    
+    /// The length of each chunk in bn254 field elements (32 bytes each).
     pub chunk_length: u32,
 }
 

--- a/src/client.rs
+++ b/src/client.rs
@@ -19,8 +19,6 @@ pub trait GetBlobData: std::fmt::Debug + Send + Sync {
         &self,
         input: &str,
     ) -> Result<Option<Vec<u8>>, Box<dyn Error + Send + Sync>>;
-
-    fn clone_boxed(&self) -> Box<dyn GetBlobData>;
 }
 
 /// EigenClient is a client for the Eigen DA service.
@@ -34,7 +32,7 @@ impl EigenClient {
     pub async fn new(
         config: EigenConfig,
         secrets: EigenSecrets,
-        get_blob_data: Box<dyn GetBlobData>,
+        get_blob_data: Arc<dyn GetBlobData>,
     ) -> Result<Self, EigenClientError> {
         let private_key = SecretKey::from_str(secrets.private_key.0.expose_secret().as_str())
             .map_err(ConfigError::Secp)?;

--- a/src/client.rs
+++ b/src/client.rs
@@ -17,7 +17,7 @@ use std::{str::FromStr, sync::Arc};
 pub trait GetBlobData: std::fmt::Debug + Send + Sync {
     async fn get_blob_data(
         &self,
-        input: &str,
+        blob_id: &str,
     ) -> Result<Option<Vec<u8>>, Box<dyn Error + Send + Sync>>;
 }
 

--- a/src/client_tests.rs
+++ b/src/client_tests.rs
@@ -4,7 +4,7 @@
 /// `cargo test client_tests -- --ignored`
 #[cfg(test)]
 mod tests {
-    use std::{str::FromStr, time::Duration};
+    use std::{str::FromStr, sync::Arc, time::Duration};
 
     use crate::{
         client::GetBlobData,
@@ -76,10 +76,6 @@ mod tests {
         ) -> Result<Option<Vec<u8>>, Box<dyn std::error::Error + Send + Sync>> {
             Ok(None)
         }
-
-        fn clone_boxed(&self) -> Box<dyn GetBlobData> {
-            Box::new(self.clone())
-        }
     }
 
     #[ignore = "depends on external RPC"]
@@ -93,7 +89,7 @@ mod tests {
             )
             .unwrap(),
         };
-        let client = EigenClient::new(config.clone(), secrets, Box::new(MockGetBlobData))
+        let client = EigenClient::new(config.clone(), secrets, Arc::new(MockGetBlobData))
             .await
             .unwrap();
         let data = vec![1; 20];
@@ -121,7 +117,7 @@ mod tests {
             )
             .unwrap(),
         };
-        let client = EigenClient::new(config.clone(), secrets, Box::new(MockGetBlobData))
+        let client = EigenClient::new(config.clone(), secrets, Arc::new(MockGetBlobData))
             .await
             .unwrap();
         let data = vec![1; 20];
@@ -150,7 +146,7 @@ mod tests {
             )
             .unwrap(),
         };
-        let client = EigenClient::new(config.clone(), secrets, Box::new(MockGetBlobData))
+        let client = EigenClient::new(config.clone(), secrets, Arc::new(MockGetBlobData))
             .await
             .unwrap();
         let data = vec![1; 20];
@@ -178,7 +174,7 @@ mod tests {
             )
             .unwrap(),
         };
-        let client = EigenClient::new(config.clone(), secrets, Box::new(MockGetBlobData))
+        let client = EigenClient::new(config.clone(), secrets, Arc::new(MockGetBlobData))
             .await
             .unwrap();
         let data = vec![1; 20];
@@ -207,7 +203,7 @@ mod tests {
             )
             .unwrap(),
         };
-        let client = EigenClient::new(config.clone(), secrets, Box::new(MockGetBlobData))
+        let client = EigenClient::new(config.clone(), secrets, Arc::new(MockGetBlobData))
             .await
             .unwrap();
         let data = vec![1; 20];

--- a/src/client_tests.rs
+++ b/src/client_tests.rs
@@ -72,7 +72,7 @@ mod tests {
     impl GetBlobData for MockGetBlobData {
         async fn get_blob_data(
             &self,
-            _input: &'_ str,
+            _blob_id: &str,
         ) -> Result<Option<Vec<u8>>, Box<dyn std::error::Error + Send + Sync>> {
             Ok(None)
         }

--- a/src/client_tests.rs
+++ b/src/client_tests.rs
@@ -33,8 +33,8 @@ mod tests {
         }
     }
 
-    const STATUS_QUERY_TIMEOUT: u64 = 1800000; // 30 minutes
-    const STATUS_QUERY_INTERVAL: u64 = 5; // 5 ms
+    const STATUS_QUERY_INTERVAL: Duration = Duration::from_millis(5);
+    const MAX_RETRY_ATTEMPTS: usize = 1800000; // With this value we retry for a duration of 30 minutes
 
     async fn get_blob_info(
         client: &EigenClient,
@@ -51,8 +51,8 @@ mod tests {
         })
         .retry(
             &ConstantBuilder::default()
-                .with_delay(Duration::from_millis(STATUS_QUERY_INTERVAL))
-                .with_max_times((STATUS_QUERY_TIMEOUT / STATUS_QUERY_INTERVAL) as usize),
+                .with_delay(STATUS_QUERY_INTERVAL)
+                .with_max_times(MAX_RETRY_ATTEMPTS),
         )
         .when(|e| {
             matches!(
@@ -86,16 +86,7 @@ mod tests {
     #[tokio::test]
     #[serial]
     async fn test_non_auth_dispersal() {
-        let config = EigenConfig {
-            disperser_rpc: "https://disperser-holesky.eigenda.xyz:443".to_string(),
-            settlement_layer_confirmation_depth: 0,
-            eigenda_eth_rpc: "https://ethereum-holesky-rpc.publicnode.com".to_string(),
-            eigenda_svc_manager_address: "0xD4A7E1Bd8015057293f0D0A557088c286942e84b".to_string(),
-            wait_for_finalization: false,
-            authenticated: false,
-            g1_url: "https://github.com/Layr-Labs/eigenda-proxy/raw/2fd70b99ef5bf137d7bbca3461cf9e1f2c899451/resources/g1.point".to_string(),
-            g2_url: "https://github.com/Layr-Labs/eigenda-proxy/raw/2fd70b99ef5bf137d7bbca3461cf9e1f2c899451/resources/g2.point.powerOf2".to_string(),
-        };
+        let config = EigenConfig::default();
         let secrets = EigenSecrets {
             private_key: PrivateKey::from_str(
                 "d08aa7ae1bb5ddd46c3c2d8cdb5894ab9f54dec467233686ca42629e826ac4c6",
@@ -121,14 +112,8 @@ mod tests {
     #[serial]
     async fn test_auth_dispersal() {
         let config = EigenConfig {
-            disperser_rpc: "https://disperser-holesky.eigenda.xyz:443".to_string(),
-            settlement_layer_confirmation_depth: 0,
-            eigenda_eth_rpc: "https://ethereum-holesky-rpc.publicnode.com".to_string(),
-            eigenda_svc_manager_address: "0xD4A7E1Bd8015057293f0D0A557088c286942e84b".to_string(),
-            wait_for_finalization: false,
             authenticated: true,
-            g1_url: "https://github.com/Layr-Labs/eigenda-proxy/raw/2fd70b99ef5bf137d7bbca3461cf9e1f2c899451/resources/g1.point".to_string(),
-            g2_url: "https://github.com/Layr-Labs/eigenda-proxy/raw/2fd70b99ef5bf137d7bbca3461cf9e1f2c899451/resources/g2.point.powerOf2".to_string(),
+            ..Default::default()
         };
         let secrets = EigenSecrets {
             private_key: PrivateKey::from_str(
@@ -155,14 +140,9 @@ mod tests {
     #[serial]
     async fn test_wait_for_finalization() {
         let config = EigenConfig {
-            disperser_rpc: "https://disperser-holesky.eigenda.xyz:443".to_string(),
             wait_for_finalization: true,
             authenticated: true,
-            g1_url: "https://github.com/Layr-Labs/eigenda-proxy/raw/2fd70b99ef5bf137d7bbca3461cf9e1f2c899451/resources/g1.point".to_string(),
-            g2_url: "https://github.com/Layr-Labs/eigenda-proxy/raw/2fd70b99ef5bf137d7bbca3461cf9e1f2c899451/resources/g2.point.powerOf2".to_string(),
-            settlement_layer_confirmation_depth: 0,
-            eigenda_eth_rpc: "https://ethereum-holesky-rpc.publicnode.com".to_string(),
-            eigenda_svc_manager_address: "0xD4A7E1Bd8015057293f0D0A557088c286942e84b".to_string(),
+            ..Default::default()
         };
         let secrets = EigenSecrets {
             private_key: PrivateKey::from_str(
@@ -189,14 +169,8 @@ mod tests {
     #[serial]
     async fn test_settlement_layer_confirmation_depth() {
         let config = EigenConfig {
-            disperser_rpc: "https://disperser-holesky.eigenda.xyz:443".to_string(),
             settlement_layer_confirmation_depth: 5,
-            eigenda_eth_rpc: "https://ethereum-holesky-rpc.publicnode.com".to_string(),
-            eigenda_svc_manager_address: "0xD4A7E1Bd8015057293f0D0A557088c286942e84b".to_string(),
-            wait_for_finalization: false,
-            authenticated: false,
-            g1_url: "https://github.com/Layr-Labs/eigenda-proxy/raw/2fd70b99ef5bf137d7bbca3461cf9e1f2c899451/resources/g1.point".to_string(),
-            g2_url: "https://github.com/Layr-Labs/eigenda-proxy/raw/2fd70b99ef5bf137d7bbca3461cf9e1f2c899451/resources/g2.point.powerOf2".to_string(),
+            ..Default::default()
         };
         let secrets = EigenSecrets {
             private_key: PrivateKey::from_str(
@@ -223,14 +197,9 @@ mod tests {
     #[serial]
     async fn test_auth_dispersal_settlement_layer_confirmation_depth() {
         let config = EigenConfig {
-            disperser_rpc: "https://disperser-holesky.eigenda.xyz:443".to_string(),
             settlement_layer_confirmation_depth: 5,
-            eigenda_eth_rpc: "https://ethereum-holesky-rpc.publicnode.com".to_string(),
-            eigenda_svc_manager_address: "0xD4A7E1Bd8015057293f0D0A557088c286942e84b".to_string(),
-            wait_for_finalization: false,
             authenticated: true,
-            g1_url: "https://github.com/Layr-Labs/eigenda-proxy/raw/2fd70b99ef5bf137d7bbca3461cf9e1f2c899451/resources/g1.point".to_string(),
-            g2_url: "https://github.com/Layr-Labs/eigenda-proxy/raw/2fd70b99ef5bf137d7bbca3461cf9e1f2c899451/resources/g2.point.powerOf2".to_string(),
+            ..Default::default()
         };
         let secrets = EigenSecrets {
             private_key: PrivateKey::from_str(

--- a/src/config.rs
+++ b/src/config.rs
@@ -1,7 +1,15 @@
+use ethereum_types::H160;
 use secrecy::{ExposeSecret, Secret};
 use std::str::FromStr;
+use url::Url;
 
 use crate::errors::{ConfigError, EigenClientError};
+
+/// Default address of the EigenDA service manager contract deployed on Holesky.
+const DEFAULT_EIGENDA_SVC_MANAGER_ADDRESS: H160 = H160([
+    0xd4, 0xa7, 0xe1, 0xbd, 0x80, 0x15, 0x05, 0x72, 0x93, 0xf0, 0xd0, 0xa5, 0x57, 0x08, 0x8c, 0x28,
+    0x69, 0x42, 0xe8, 0x4b,
+]);
 
 /// Configuration for the EigenDA remote disperser client.
 #[derive(Clone, Debug, PartialEq)]
@@ -9,16 +17,18 @@ pub struct EigenConfig {
     /// URL of the Disperser RPC server
     pub disperser_rpc: String,
     /// URL of the Ethereum RPC server
-    pub eigenda_eth_rpc: String,
+    pub eigenda_eth_rpc: Option<String>,
     /// Block height needed to reach in order to consider the blob finalized
     /// a value less or equal to 0 means that the disperser will not wait for finalization
     pub settlement_layer_confirmation_depth: u32,
     /// Address of the service manager contract
-    pub eigenda_svc_manager_address: String,
+    pub eigenda_svc_manager_address: H160,
     /// Wait for the blob to be finalized before returning the response
     pub wait_for_finalization: bool,
     /// Authenticated dispersal
     pub authenticated: bool,
+    /// Optional path to downloaded points directory
+    pub points_dir: Option<String>,
     /// Url to the file containing the G1 point used for KZG
     pub g1_url: String,
     /// Url to the file containing the G2 point used for KZG
@@ -30,10 +40,11 @@ impl Default for EigenConfig {
         Self {
             disperser_rpc: "https://disperser-holesky.eigenda.xyz:443".to_string(),
             settlement_layer_confirmation_depth: 0,
-            eigenda_eth_rpc: "https://ethereum-holesky-rpc.publicnode.com".to_string(),
-            eigenda_svc_manager_address: "0xD4A7E1Bd8015057293f0D0A557088c286942e84b".to_string(),
+            eigenda_eth_rpc: Some("foo".to_string()), // Secret::new(Url::from_str("https://ethereum-holesky-rpc.publicnode.com").unwrap()), // Safe to unwrap, never fails
+            eigenda_svc_manager_address: DEFAULT_EIGENDA_SVC_MANAGER_ADDRESS,
             wait_for_finalization: false,
             authenticated: false,
+            points_dir: None,
             g1_url: "https://github.com/Layr-Labs/eigenda-proxy/raw/2fd70b99ef5bf137d7bbca3461cf9e1f2c899451/resources/g1.point".to_string(),
             g2_url: "https://github.com/Layr-Labs/eigenda-proxy/raw/2fd70b99ef5bf137d7bbca3461cf9e1f2c899451/resources/g2.point.powerOf2".to_string(),
         }

--- a/src/config.rs
+++ b/src/config.rs
@@ -6,10 +6,9 @@ use url::Url;
 use crate::errors::{ConfigError, EigenClientError};
 
 /// Default address of the EigenDA service manager contract deployed on Holesky.
-const DEFAULT_EIGENDA_SVC_MANAGER_ADDRESS: H160 = H160([
-    0xd4, 0xa7, 0xe1, 0xbd, 0x80, 0x15, 0x05, 0x72, 0x93, 0xf0, 0xd0, 0xa5, 0x57, 0x08, 0x8c, 0x28,
-    0x69, 0x42, 0xe8, 0x4b,
-]);
+const EIGENDA_SVC_MANAGER_HOLESKY_ADDRESS: H160 = H160(hex_literal::hex!(
+    "d4a7e1bd8015057293f0d0a557088c286942e84b"
+));
 
 #[derive(Debug, Clone)]
 /// A URL stored securely using the `Secret` type from the secrecy crate
@@ -46,7 +45,7 @@ pub struct EigenConfig {
     /// URL of the Disperser RPC server
     pub disperser_rpc: String,
     /// URL of the Ethereum RPC server
-    pub eigenda_eth_rpc: Option<SecretUrl>,
+    pub eth_rpc_url: Option<SecretUrl>,
     /// Block height needed to reach in order to consider the blob finalized
     /// a value less or equal to 0 means that the disperser will not wait for finalization
     pub settlement_layer_confirmation_depth: u32,
@@ -57,7 +56,7 @@ pub struct EigenConfig {
     /// Authenticated dispersal
     pub authenticated: bool,
     /// Optional path to downloaded points directory
-    pub points_dir: Option<String>,
+    pub srs_points_dir: Option<String>,
     /// Url to the file containing the G1 point used for KZG
     pub g1_url: String,
     /// Url to the file containing the G2 point used for KZG
@@ -69,11 +68,11 @@ impl Default for EigenConfig {
         Self {
             disperser_rpc: "https://disperser-holesky.eigenda.xyz:443".to_string(),
             settlement_layer_confirmation_depth: 0,
-            eigenda_eth_rpc: Some(SecretUrl::new(Url::from_str("https://ethereum-holesky-rpc.publicnode.com").unwrap())), // Safe to unwrap, never fails
-            eigenda_svc_manager_address: DEFAULT_EIGENDA_SVC_MANAGER_ADDRESS,
+            eth_rpc_url: Some(SecretUrl::new(Url::from_str("https://ethereum-holesky-rpc.publicnode.com").unwrap())), // Safe to unwrap, never fails
+            eigenda_svc_manager_address: EIGENDA_SVC_MANAGER_HOLESKY_ADDRESS,
             wait_for_finalization: false,
             authenticated: false,
-            points_dir: None,
+            srs_points_dir: None,
             g1_url: "https://github.com/Layr-Labs/eigenda-proxy/raw/2fd70b99ef5bf137d7bbca3461cf9e1f2c899451/resources/g1.point".to_string(),
             g2_url: "https://github.com/Layr-Labs/eigenda-proxy/raw/2fd70b99ef5bf137d7bbca3461cf9e1f2c899451/resources/g2.point.powerOf2".to_string(),
         }

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -24,6 +24,8 @@ pub enum EigenClientError {
 pub enum ConfigError {
     #[error("Private Key Error")]
     PrivateKey,
+    #[error("ETH RPC not set")]
+    NoEthRpc,
     #[error(transparent)]
     Secp(#[from] secp256k1::Error),
     #[error(transparent)]

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -1,7 +1,8 @@
+use ark_bn254::G1Affine;
 use tokio::sync::mpsc::error::SendError;
 use tonic::{transport::Error as TonicError, Status};
 
-use crate::{eth_client::RpcErrorResponse, generated::disperser};
+use crate::{blob_info::BlobQuorumParam, eth_client::RpcErrorResponse, generated::disperser};
 
 /// Errors returned by this crate
 #[derive(Debug, thiserror::Error)]
@@ -77,6 +78,8 @@ pub enum BlobStatusError {
 pub enum ConversionError {
     #[error("Failed to convert {0}")]
     NotPresent(String),
+    #[error("Failed to cast {0}")]
+    Cast(String),
 }
 
 /// Errors for the EthClient
@@ -87,36 +90,57 @@ pub enum EthClientError {
     #[error(transparent)]
     SerdeJSON(#[from] serde_json::Error),
     #[error("RPC: {0}")]
-    RPC(RpcErrorResponse),
+    Rpc(RpcErrorResponse),
+}
+
+#[derive(Debug, thiserror::Error)]
+pub enum KzgError {
+    #[error("Kzg setup error: {0}")]
+    Setup(String),
+    #[error(transparent)]
+    Internal(#[from] rust_kzg_bn254::errors::KzgError),
+}
+
+#[derive(Debug, thiserror::Error)]
+pub enum ServiceManagerError {
+    #[error(transparent)]
+    EthClient(#[from] EthClientError),
+    #[error("Decoding error: {0}")]
+    Decoding(String),
 }
 
 /// Errors for the Verifier
 #[derive(Debug, thiserror::Error)]
 pub enum VerificationError {
-    #[error("Service Manager Error: {0}")]
-    ServiceManager(String),
-    #[error("Kzg Error: {0}")]
-    Kzg(String),
+    #[error(transparent)]
+    ServiceManager(#[from] ServiceManagerError),
+    #[error(transparent)]
+    Kzg(#[from] KzgError),
     #[error("Wrong proof")]
     WrongProof,
-    #[error("Different commitments")]
-    DifferentCommitments,
-    #[error("Different roots")]
-    DifferentRoots,
+    #[error("Different commitments: expected {expected:?}, got {actual:?}")]
+    DifferentCommitments {
+        expected: Box<G1Affine>,
+        actual: Box<G1Affine>,
+    },
+    #[error("Different roots: expected {expected:?}, got {actual:?}")]
+    DifferentRoots { expected: String, actual: String },
     #[error("Empty hashes")]
     EmptyHash,
-    #[error("Different hashes")]
-    DifferentHashes,
-    #[error("Wrong quorum params")]
-    WrongQuorumParams,
+    #[error("Different hashes: expected {expected:?}, got {actual:?}")]
+    DifferentHashes { expected: String, actual: String },
+    #[error("Wrong quorum params: {blob_quorum_params:?}")]
+    WrongQuorumParams { blob_quorum_params: BlobQuorumParam },
     #[error("Quorum not confirmed")]
     QuorumNotConfirmed,
-    #[error("Commitment not on curve")]
-    CommitmentNotOnCurve,
-    #[error("Commitment not on correct subgroup")]
-    CommitmentNotOnCorrectSubgroup,
+    #[error("Commitment not on curve: {0}")]
+    CommitmentNotOnCurve(G1Affine),
+    #[error("Commitment not on correct subgroup: {0}")]
+    CommitmentNotOnCorrectSubgroup(G1Affine),
     #[error("Point download error: {0}")]
     PointDownloadError(String),
     #[error("Data Mismatch")]
     DataMismatch,
+    #[error(transparent)]
+    Conversion(#[from] ConversionError),
 }

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -25,8 +25,8 @@ pub enum EigenClientError {
 pub enum ConfigError {
     #[error("Private Key Error")]
     PrivateKey,
-    #[error("ETH RPC not set")]
-    NoEthRpc,
+    #[error("ETH RPC URL not set")]
+    NoEthRpcUrl,
     #[error(transparent)]
     Secp(#[from] secp256k1::Error),
     #[error(transparent)]

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -113,8 +113,8 @@ pub enum VerificationError {
     CommitmentNotOnCurve,
     #[error("Commitment not on correct subgroup")]
     CommitmentNotOnCorrectSubgroup,
-    #[error("Link Error: {0}")]
-    Link(String),
+    #[error("Point download error: {0}")]
+    PointDownloadError(String),
     #[error("Data Mismatch")]
     DataMismatch,
 }

--- a/src/eth_client.rs
+++ b/src/eth_client.rs
@@ -107,7 +107,7 @@ impl EthClient {
             Ok(RpcResponse::Success(result)) => {
                 serde_json::from_value(result.result).map_err(EthClientError::SerdeJSON)
             }
-            Ok(RpcResponse::Error(error_response)) => Err(EthClientError::RPC(error_response)),
+            Ok(RpcResponse::Error(error_response)) => Err(EthClientError::Rpc(error_response)),
             Err(error) => Err(error),
         }
     }
@@ -141,7 +141,7 @@ impl EthClient {
             Ok(RpcResponse::Success(result)) => {
                 serde_json::from_value(result.result).map_err(EthClientError::SerdeJSON)
             }
-            Ok(RpcResponse::Error(error_response)) => Err(EthClientError::RPC(error_response)),
+            Ok(RpcResponse::Error(error_response)) => Err(EthClientError::Rpc(error_response)),
             Err(error) => Err(error),
         }
     }

--- a/src/eth_client.rs
+++ b/src/eth_client.rs
@@ -69,14 +69,16 @@ pub(crate) struct RpcRequest {
 pub(crate) struct EthClient {
     client: reqwest::Client,
     pub(crate) url: SecretUrl,
+    pub(crate) svc_manager_addr: Address,
 }
 
 impl EthClient {
     /// Creates a new EthClient
-    pub(crate) fn new(url: SecretUrl) -> Self {
+    pub(crate) fn new(url: SecretUrl, svc_manager_addr: Address) -> Self {
         Self {
             client: reqwest::Client::new(),
             url,
+            svc_manager_addr,
         }
     }
 

--- a/src/sdk.rs
+++ b/src/sdk.rs
@@ -143,7 +143,7 @@ impl RawEigenClient {
             .next()
             .await
             .ok_or(CommunicationError::NoResponseFromServer)?
-            .unwrap()
+            .map_err(BlobStatusError::Status)?
             .payload
             .ok_or(CommunicationError::NoPayloadInResponse)?;
 

--- a/src/verifier.rs
+++ b/src/verifier.rs
@@ -181,7 +181,7 @@ impl VerifierClient for EthClient {
 /// EigenDA service manager is used to connect to the service manager contract
 #[derive(Debug, Clone)]
 pub(crate) struct Verifier {
-    kzg: Kzg,
+    kzg: Arc<Kzg>,
     cfg: EigenConfig,
     eth_client: Arc<dyn VerifierClient>,
 }
@@ -270,7 +270,7 @@ impl Verifier {
             .map_err(|e| VerificationError::Kzg(KzgError::Setup(e.to_string())))??;
 
         Ok(Self {
-            kzg,
+            kzg: Arc::new(kzg),
             cfg,
             eth_client,
         })

--- a/src/verifier_tests.rs
+++ b/src/verifier_tests.rs
@@ -81,7 +81,6 @@ mod test {
 
             let calldata = bytes::Bytes::copy_from_slice(&data);
 
-            // let req = serde_json::to_string(&call_request).unwrap();
             let req = serde_json::to_string(&calldata).unwrap();
             let res = self.replies.get(&req).unwrap().clone();
             decode_bytes(res.to_vec())

--- a/src/verifier_tests.rs
+++ b/src/verifier_tests.rs
@@ -4,23 +4,24 @@ mod test {
         BatchHeader, BatchMetadata, BlobHeader, BlobInfo, BlobQuorumParam, BlobVerificationProof,
         G1Commitment,
     };
+    use crate::config::EigenConfig;
     use crate::errors::EthClientError;
     use crate::eth_client::EthClient;
-    use crate::verifier::{Verifier, VerifierClient, VerifierConfig};
+    use crate::verifier::{Verifier, VerifierClient};
     use ethereum_types::{Address, U256};
     use std::collections::HashMap;
     use std::str::FromStr;
     use url::Url;
 
-    fn get_verifier_config() -> VerifierConfig {
-        VerifierConfig {
-            svc_manager_addr: Address::from_str("0xD4A7E1Bd8015057293f0D0A557088c286942e84b").unwrap(),
-            max_blob_size: 2 * 1024 * 1024,
-            g1_url: Url::parse("https://github.com/Layr-Labs/eigenda-proxy/raw/2fd70b99ef5bf137d7bbca3461cf9e1f2c899451/resources/g1.point").unwrap(),
-            g2_url: Url::parse("https://github.com/Layr-Labs/eigenda-proxy/raw/2fd70b99ef5bf137d7bbca3461cf9e1f2c899451/resources/g2.point.powerOf2").unwrap(),
-            settlement_layer_confirmation_depth: 0,
-        }
-    }
+    // fn get_verifier_config() -> VerifierConfig {
+    //     VerifierConfig {
+    //         svc_manager_addr: Address::from_str("0xD4A7E1Bd8015057293f0D0A557088c286942e84b").unwrap(),
+    //         max_blob_size: 2 * 1024 * 1024,
+    //         g1_url: Url::parse("https://github.com/Layr-Labs/eigenda-proxy/raw/2fd70b99ef5bf137d7bbca3461cf9e1f2c899451/resources/g1.point").unwrap(),
+    //         g2_url: Url::parse("https://github.com/Layr-Labs/eigenda-proxy/raw/2fd70b99ef5bf137d7bbca3461cf9e1f2c899451/resources/g2.point.powerOf2").unwrap(),
+    //         settlement_layer_confirmation_depth: 0,
+    //     }
+    // }
 
     /// Mock struct for the Verifier
     /// Used to avoid making actual calls to a remote disperser
@@ -64,7 +65,7 @@ mod test {
     #[ignore = "depends on external RPC"]
     #[tokio::test]
     async fn test_verify_commitment() {
-        let cfg = get_verifier_config();
+        let cfg = EigenConfig::default();
         let eth_client = EthClient::new("https://ethereum-holesky-rpc.publicnode.com");
         let verifier = Verifier::new(cfg, eth_client).await.unwrap();
         let commitment = G1Commitment {
@@ -86,7 +87,7 @@ mod test {
     /// To test actual behaviour of the verifier, run the test above
     #[tokio::test]
     async fn test_verify_commitment_mocked() {
-        let cfg = get_verifier_config();
+        let cfg = EigenConfig::default();
         let signing_client = MockVerifierClient::new(HashMap::new());
         let verifier = Verifier::new(cfg, signing_client).await.unwrap();
         let commitment = G1Commitment {
@@ -107,7 +108,7 @@ mod test {
     #[ignore = "depends on external RPC"]
     #[tokio::test]
     async fn test_verify_merkle_proof() {
-        let cfg = get_verifier_config();
+        let cfg = EigenConfig::default();
         let eth_client = EthClient::new("https://ethereum-holesky-rpc.publicnode.com");
         let verifier = Verifier::new(cfg, eth_client).await.unwrap();
         let cert = BlobInfo {
@@ -190,7 +191,7 @@ mod test {
     /// To test actual behaviour of the verifier, run the test above
     #[tokio::test]
     async fn test_verify_merkle_proof_mocked() {
-        let cfg = get_verifier_config();
+        let cfg = EigenConfig::default();
         let signing_client = MockVerifierClient::new(HashMap::new());
         let verifier = Verifier::new(cfg, signing_client).await.unwrap();
         let cert = BlobInfo {
@@ -272,7 +273,7 @@ mod test {
     #[ignore = "depends on external RPC"]
     #[tokio::test]
     async fn test_hash_blob_header() {
-        let cfg = get_verifier_config();
+        let cfg = EigenConfig::default();
         let eth_client = EthClient::new("https://ethereum-holesky-rpc.publicnode.com");
         let verifier = Verifier::new(cfg, eth_client).await.unwrap();
         let blob_header = BlobHeader {
@@ -311,7 +312,7 @@ mod test {
     /// To test actual behaviour of the verifier, run the test above
     #[tokio::test]
     async fn test_hash_blob_header_mocked() {
-        let cfg = get_verifier_config();
+        let cfg = EigenConfig::default();
         let signing_client = MockVerifierClient::new(HashMap::new());
         let verifier = Verifier::new(cfg, signing_client).await.unwrap();
         let blob_header = BlobHeader {
@@ -349,7 +350,7 @@ mod test {
     #[ignore = "depends on external RPC"]
     #[tokio::test]
     async fn test_inclusion_proof() {
-        let cfg = get_verifier_config();
+        let cfg = EigenConfig::default();
         let eth_client = EthClient::new("https://ethereum-holesky-rpc.publicnode.com");
         let verifier = Verifier::new(cfg, eth_client).await.unwrap();
         let proof = hex::decode("c455c1ea0e725d7ea3e5f29e9f48be8fc2787bb0a914d5a86710ba302c166ac4f626d76f67f1055bb960a514fb8923af2078fd84085d712655b58a19612e8cd15c3e4ac1cef57acde3438dbcf63f47c9fefe1221344c4d5c1a4943dd0d1803091ca81a270909dc0e146841441c9bd0e08e69ce6168181a3e4060ffacf3627480bec6abdd8d7bb92b49d33f180c42f49e041752aaded9c403db3a17b85e48a11e9ea9a08763f7f383dab6d25236f1b77c12b4c49c5cdbcbea32554a604e3f1d2f466851cb43fe73617b3d01e665e4c019bf930f92dea7394c25ed6a1e200d051fb0c30a2193c459f1cfef00bf1ba6656510d16725a4d1dc031cb759dbc90bab427b0f60ddc6764681924dda848824605a4f08b7f526fe6bd4572458c94e83fbf2150f2eeb28d3011ec921996dc3e69efa52d5fcf3182b20b56b5857a926aa66605808079b4d52c0c0cfe06923fa92e65eeca2c3e6126108e8c1babf5ac522f4d7").unwrap();
@@ -370,7 +371,7 @@ mod test {
     /// To test actual behaviour of the verifier, run the test above
     #[tokio::test]
     async fn test_inclusion_proof_mocked() {
-        let cfg = get_verifier_config();
+        let cfg = EigenConfig::default();
         let signing_client = MockVerifierClient::new(HashMap::new());
         let verifier = Verifier::new(cfg, signing_client).await.unwrap();
         let proof = hex::decode("c455c1ea0e725d7ea3e5f29e9f48be8fc2787bb0a914d5a86710ba302c166ac4f626d76f67f1055bb960a514fb8923af2078fd84085d712655b58a19612e8cd15c3e4ac1cef57acde3438dbcf63f47c9fefe1221344c4d5c1a4943dd0d1803091ca81a270909dc0e146841441c9bd0e08e69ce6168181a3e4060ffacf3627480bec6abdd8d7bb92b49d33f180c42f49e041752aaded9c403db3a17b85e48a11e9ea9a08763f7f383dab6d25236f1b77c12b4c49c5cdbcbea32554a604e3f1d2f466851cb43fe73617b3d01e665e4c019bf930f92dea7394c25ed6a1e200d051fb0c30a2193c459f1cfef00bf1ba6656510d16725a4d1dc031cb759dbc90bab427b0f60ddc6764681924dda848824605a4f08b7f526fe6bd4572458c94e83fbf2150f2eeb28d3011ec921996dc3e69efa52d5fcf3182b20b56b5857a926aa66605808079b4d52c0c0cfe06923fa92e65eeca2c3e6126108e8c1babf5ac522f4d7").unwrap();
@@ -390,7 +391,7 @@ mod test {
     #[ignore = "depends on external RPC"]
     #[tokio::test]
     async fn test_verify_batch() {
-        let cfg = get_verifier_config();
+        let cfg = EigenConfig::default();
         let eth_client = EthClient::new("https://ethereum-holesky-rpc.publicnode.com");
         let verifier = Verifier::new(cfg, eth_client).await.unwrap();
         let cert = BlobInfo {
@@ -485,7 +486,7 @@ mod test {
         );
         mock_replies.insert(mock_req, mock_res);
 
-        let cfg = get_verifier_config();
+        let cfg = EigenConfig::default();
         let signing_client = MockVerifierClient::new(mock_replies);
         let verifier = Verifier::new(cfg, signing_client).await.unwrap();
         let cert = BlobInfo {
@@ -567,7 +568,7 @@ mod test {
     // #[ignore = "depends on external RPC"]
     #[tokio::test]
     async fn test_verify_security_params() {
-        let cfg = get_verifier_config();
+        let cfg = EigenConfig::default();
         let eth_client = EthClient::new("https://ethereum-holesky-rpc.publicnode.com");
         let verifier = Verifier::new(cfg, eth_client).await.unwrap();
         let cert = BlobInfo {
@@ -670,7 +671,7 @@ mod test {
         );
         mock_replies.insert(mock_req, mock_res);
 
-        let cfg = get_verifier_config();
+        let cfg = EigenConfig::default();
         let signing_client = MockVerifierClient::new(mock_replies);
         let verifier = Verifier::new(cfg, signing_client).await.unwrap();
         let cert = BlobInfo {


### PR DESCRIPTION
Update eigen client with changes needed to make it work with M0 implementation for zksync-era

- Make `eigenda_eth_rpc` secure using `Secret`
- Redesign some errors
- Simplify padding functions
- Add an option to load kzg points from a directory
- Download kzg points into a temporary file instead of root directory
- Redesign VerifierClient Trait so that it is higher level