### PR TITLE
chore: Remove unneeded dependency

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,7 +19,6 @@ ethereum-types = { version = "0.14.1", features = ["serialize"] }
 prost = "0.12.6"
 tonic = { version = "0.11.0", features = ["tls-roots", "prost", "codegen"] }
 secp256k1 = { version = "0.27.0", features = ["recovery", "global-context"] }
-subxt-signer = { version = "0.34", features = ["sr25519", "native"] }
 bytes = {version= "1", features = ["serde"]}
 reqwest = {version = "0.12", features = ["json"] }
 serde = "1"


### PR DESCRIPTION
This PR removes `subxt-signer` dependency, since it is not used anymore and it would make the cargo license check in zksync's CI fail, due to it having the dependency `instant` which is unmaintained.