### PR TITLE
Force `EigenConfig` to have an `eth_rpc_url`

### DIFF
--- a/src/client_tests.rs
+++ b/src/client_tests.rs
@@ -196,7 +196,7 @@ mod tests {
         assert_eq!(retrieved_data.unwrap(), data);
     }
 
-    // #[ignore = "depends on external RPC"]
+    #[ignore = "depends on external RPC"]
     #[tokio::test]
     #[serial]
     async fn test_auth_dispersal_settlement_layer_confirmation_depth() {

--- a/src/client_tests.rs
+++ b/src/client_tests.rs
@@ -98,7 +98,9 @@ mod tests {
         let blob_info = get_blob_info(&client, &result).await.unwrap();
         let expected_inclusion_data = blob_info.clone().blob_verification_proof.inclusion_proof;
         let actual_inclusion_data = client.get_inclusion_data(&result).await.unwrap().unwrap();
-        assert_eq!(expected_inclusion_data, actual_inclusion_data);
+        assert!(actual_inclusion_data
+            .windows(expected_inclusion_data.len())
+            .any(|window| window == expected_inclusion_data)); // Checks that the verification proof is included in the inclusion data
         let retrieved_data = client.get_blob(blob_info).await.unwrap();
         assert_eq!(retrieved_data.unwrap(), data);
     }
@@ -126,7 +128,9 @@ mod tests {
 
         let expected_inclusion_data = blob_info.clone().blob_verification_proof.inclusion_proof;
         let actual_inclusion_data = client.get_inclusion_data(&result).await.unwrap().unwrap();
-        assert_eq!(expected_inclusion_data, actual_inclusion_data);
+        assert!(actual_inclusion_data
+            .windows(expected_inclusion_data.len())
+            .any(|window| window == expected_inclusion_data)); // Checks that the verification proof is included in the inclusion data
         let retrieved_data = client.get_blob(blob_info).await.unwrap();
         assert_eq!(retrieved_data.unwrap(), data);
     }
@@ -155,7 +159,9 @@ mod tests {
 
         let expected_inclusion_data = blob_info.clone().blob_verification_proof.inclusion_proof;
         let actual_inclusion_data = client.get_inclusion_data(&result).await.unwrap().unwrap();
-        assert_eq!(expected_inclusion_data, actual_inclusion_data);
+        assert!(actual_inclusion_data
+            .windows(expected_inclusion_data.len())
+            .any(|window| window == expected_inclusion_data)); // Checks that the verification proof is included in the inclusion data
         let retrieved_data = client.get_blob(blob_info).await.unwrap();
         assert_eq!(retrieved_data.unwrap(), data);
     }
@@ -183,12 +189,14 @@ mod tests {
 
         let expected_inclusion_data = blob_info.clone().blob_verification_proof.inclusion_proof;
         let actual_inclusion_data = client.get_inclusion_data(&result).await.unwrap().unwrap();
-        assert_eq!(expected_inclusion_data, actual_inclusion_data);
+        assert!(actual_inclusion_data
+            .windows(expected_inclusion_data.len())
+            .any(|window| window == expected_inclusion_data)); // Checks that the verification proof is included in the inclusion data
         let retrieved_data = client.get_blob(blob_info).await.unwrap();
         assert_eq!(retrieved_data.unwrap(), data);
     }
 
-    #[ignore = "depends on external RPC"]
+    // #[ignore = "depends on external RPC"]
     #[tokio::test]
     #[serial]
     async fn test_auth_dispersal_settlement_layer_confirmation_depth() {
@@ -212,7 +220,9 @@ mod tests {
 
         let expected_inclusion_data = blob_info.clone().blob_verification_proof.inclusion_proof;
         let actual_inclusion_data = client.get_inclusion_data(&result).await.unwrap().unwrap();
-        assert_eq!(expected_inclusion_data, actual_inclusion_data);
+        assert!(actual_inclusion_data
+            .windows(expected_inclusion_data.len())
+            .any(|window| window == expected_inclusion_data)); // Checks that the verification proof is included in the inclusion data
         let retrieved_data = client.get_blob(blob_info).await.unwrap();
         assert_eq!(retrieved_data.unwrap(), data);
     }

--- a/src/config.rs
+++ b/src/config.rs
@@ -48,7 +48,7 @@ pub struct EigenConfig {
     /// URL of the Disperser RPC server
     pub disperser_rpc: String,
     /// URL of the Ethereum RPC server
-    pub eth_rpc_url: Option<SecretUrl>,
+    pub eth_rpc_url: SecretUrl,
     /// Block height needed to reach in order to consider the blob finalized
     /// a value less or equal to 0 means that the disperser will not wait for finalization
     pub settlement_layer_confirmation_depth: u32,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -27,7 +27,7 @@ pub fn test_eigenda_config() -> crate::config::EigenConfig {
     crate::config::EigenConfig {
                 disperser_rpc: "https://disperser-holesky.eigenda.xyz:443".to_string(),
                 settlement_layer_confirmation_depth: 0,
-                eth_rpc_url: Some(crate::config::SecretUrl::new(url::Url::from_str("https://ethereum-holesky-rpc.publicnode.com").unwrap())), // Safe to unwrap, never fails
+                eth_rpc_url: crate::config::SecretUrl::new(url::Url::from_str("https://ethereum-holesky-rpc.publicnode.com").unwrap()), // Safe to unwrap, never fails
                 eigenda_svc_manager_address: ethereum_types::H160(hex_literal::hex!(
                     "d4a7e1bd8015057293f0d0a557088c286942e84b"
                 )),

--- a/src/sdk.rs
+++ b/src/sdk.rs
@@ -57,7 +57,7 @@ impl RawEigenClient {
                 .map_err(ConfigError::Tonic)?,
         ));
 
-        let url = config.eth_rpc_url.clone().ok_or(ConfigError::NoEthRpcUrl)?;
+        let url = config.eth_rpc_url.clone();
         let eth_client = eth_client::EthClient::new(url, config.eigenda_svc_manager_address);
 
         let verifier = Verifier::new(config.clone(), eth_client).await?;


### PR DESCRIPTION
Remove `Option` wrapping for the `eth_rpc_url`,  this change is due to the unclear handling of a possible empty rpc being set in the config, which lacks sense. `RawEigenClient::new()` no longer fails in case `eth_rpc_url` is `None`.

[Comment that this PR originates from](https://github.com/matter-labs/zksync-era/pull/3650/files/d03820e68b4dca2aafcca47c6266cbc6d9ac9a69#r1983277737)