### PR TITLE
Make `EigenConfig` fields public to crate only & change rust version

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,5 +1,5 @@
 [workspace]
-resolver = "3"
+resolver = "2"
 
 members = [
     "crates/rust-eigenda-client",
@@ -11,7 +11,7 @@ authors = ["Layr Labs"]
 description = "EigenDA Clients"
 repository = "https://github.com/Layr-Labs/eigenda-client-rs"
 license = "MIT OR Apache-2.0"
-edition = "2024"
+edition = "2021"
 
 
 [workspace.dependencies]

--- a/crates/rust-eigenda-client/src/config.rs
+++ b/crates/rust-eigenda-client/src/config.rs
@@ -46,22 +46,55 @@ pub enum SrsPointsSource {
 #[derive(Clone, Debug, PartialEq)]
 pub struct EigenConfig {
     /// URL of the Disperser RPC server
-    pub disperser_rpc: String,
+    pub(crate) disperser_rpc: String,
     /// URL of the Ethereum RPC server
-    pub eth_rpc_url: SecretUrl,
+    pub(crate) eth_rpc_url: SecretUrl,
     /// Block height needed to reach in order to consider the blob finalized
     /// a value less or equal to 0 means that the disperser will not wait for finalization
-    pub settlement_layer_confirmation_depth: u32,
+    pub(crate) settlement_layer_confirmation_depth: u32,
     /// Address of the service manager contract
-    pub eigenda_svc_manager_address: H160,
+    pub(crate) eigenda_svc_manager_address: H160,
     /// Wait for the blob to be finalized before returning the response
-    pub wait_for_finalization: bool,
+    pub(crate) wait_for_finalization: bool,
     /// Authenticated dispersal
-    pub authenticated: bool,
+    pub(crate) authenticated: bool,
     /// Points source
-    pub srs_points_source: SrsPointsSource,
+    pub(crate) srs_points_source: SrsPointsSource,
     /// Custom quorum numbers
-    pub custom_quorum_numbers: Vec<u32>,
+    pub(crate) custom_quorum_numbers: Vec<u32>,
+}
+
+impl EigenConfig {
+    /// Create a new EigenConfig
+    pub fn new(
+        disperser_rpc: String,
+        eth_rpc_url: SecretUrl,
+        settlement_layer_confirmation_depth: u32,
+        eigenda_svc_manager_address: H160,
+        wait_for_finalization: bool,
+        authenticated: bool,
+        srs_points_source: SrsPointsSource,
+        custom_quorum_numbers: Vec<u32>,
+    ) -> Result<Self, ConfigError> {
+
+        custom_quorum_numbers.iter().try_for_each(|&x| {
+            if x > 255 {
+                return Err(ConfigError::InvalidQuorumNumber(x));
+            }
+            Ok(())
+        })?;
+
+        Ok(Self {
+            disperser_rpc,
+            eth_rpc_url,
+            settlement_layer_confirmation_depth,
+            eigenda_svc_manager_address,
+            wait_for_finalization,
+            authenticated,
+            srs_points_source,
+            custom_quorum_numbers,
+        })
+    }
 }
 
 /// Contains the private key

--- a/crates/rust-eigenda-client/src/errors.rs
+++ b/crates/rust-eigenda-client/src/errors.rs
@@ -27,6 +27,8 @@ pub enum ConfigError {
     PrivateKey,
     #[error("ETH RPC URL not set")]
     NoEthRpcUrl,
+    #[error("Invalid Quorum Number: {0}")]
+    InvalidQuorumNumber(u32),
     #[error(transparent)]
     Secp(#[from] secp256k1::Error),
     #[error(transparent)]

--- a/crates/rust-eigenda-v2-client/Cargo.toml
+++ b/crates/rust-eigenda-v2-client/Cargo.toml
@@ -4,7 +4,7 @@
 # and move them into the eigenda monorepo.
 name = "rust-eigenda-v2-client"
 version = "0.1.0"
-edition = "2024"
+edition = "2021"
 repository = "https://github.com/Layr-Labs/eigenda-client-rs"
 description = "EigenDA Client"
 license = "MIT OR Apache-2.0"


### PR DESCRIPTION
- Make instantiation of `EigenConfig` with `new` instead of directly accessing fields, to be able to check correct usage of them. ([example here](https://github.com/matter-labs/zksync-era/pull/3719#discussion_r1999193196)).
- Rollback rust version from 2024 to 2021, to avoid crate issues when being used with repositories like matter-labs zksync-era.