### PR TITLE
feat: update crate version

### DIFF
--- a/crates/rust-eigenda-client/Cargo.toml
+++ b/crates/rust-eigenda-client/Cargo.toml
@@ -5,7 +5,7 @@
 name = "rust-eigenda-client"
 repository = "https://github.com/Layr-Labs/eigenda-client-rs"
 description = "EigenDA Client"
-version = "0.1.2"
+version = "0.1.3"
 edition = "2021"
 license = "MIT OR Apache-2.0"
 exclude = [


### PR DESCRIPTION
Update V1 client crate to `0.1.3`:
- Change `EigenConfig` to only be created via `new` method for safety purposes.