### PR TITLE
Client v2: add payload module

### DIFF
--- a/crates/rust-eigenda-v2-client/Cargo.toml
+++ b/crates/rust-eigenda-v2-client/Cargo.toml
@@ -33,5 +33,7 @@ ethereum-types = { workspace = true }
 prost = { workspace = true }
 tonic = { workspace = true }
 tokio-stream = { workspace = true }
+ark-bn254 = {workspace = true }
 rust-kzg-bn254-primitives = "0.1.0"
 rust-kzg-bn254-verifier = "0.1.0"
+ark-poly = "0.5.0"

--- a/crates/rust-eigenda-v2-client/src/core/blob.rs
+++ b/crates/rust-eigenda-v2-client/src/core/blob.rs
@@ -1,1 +1,23 @@
+use ark_bn254::Fr;
 
+// Blob is data that is dispersed on eigenDA.
+//
+// A Blob is represented under the hood by an array of field elements, which represent a polynomial in coefficient form
+pub(crate) struct Blob {
+    pub coeff_polynomial: Vec<Fr>,
+    // blobLengthSymbols must be a power of 2, and should match the blobLength claimed in the BlobCommitment
+    //
+    // This value must be specified, rather than computed from the length of the coeffPolynomial, due to an edge case
+    // illustrated by the following example: imagine a user disperses a very small blob, only 64 bytes, and the last 40
+    // bytes are trailing zeros. When a different user fetches the blob from a relay, it's possible that the relay could
+    // truncate the trailing zeros. If we were to say that blobLengthSymbols = nextPowerOf2(len(coeffPolynomial)), then the
+    // user fetching and reconstructing this blob would determine that the blob length is 1 symbol, when it's actually 2.
+    pub blobLengthSymbols: u32,
+}
+
+impl Blob {
+    /// Initializes a blob from a polynomial
+    pub fn from_polynomial(_coeff_polynomial: Vec<Fr>, _blobLengthSymbols: u32) -> Self {
+        todo!()
+    }
+}

--- a/crates/rust-eigenda-v2-client/src/core/encoded_payload.rs
+++ b/crates/rust-eigenda-v2-client/src/core/encoded_payload.rs
@@ -1,1 +1,15 @@
+use ark_bn254::Fr;
 
+use super::payload::Payload;
+
+pub(crate) struct EncodedPayload {}
+
+impl EncodedPayload {
+    pub fn new(payload: &Payload) -> Self {
+        EncodedPayload {}
+    }
+
+    pub(crate) fn to_field_elements(&self) -> Vec<Fr> {
+        todo!()
+    }
+}

--- a/crates/rust-eigenda-v2-client/src/core/payload.rs
+++ b/crates/rust-eigenda-v2-client/src/core/payload.rs
@@ -1,1 +1,63 @@
+use ark_bn254::Fr;
+use ark_poly::{EvaluationDomain, GeneralEvaluationDomain};
 
+use super::{blob::Blob, encoded_payload::EncodedPayload};
+
+// TODO: remove, this will be implemented somewhere else
+enum PayloadForm {
+    Eval,
+    Coeff,
+}
+
+/// Payload represents arbitrary user data, without any processing.
+pub(crate) struct Payload {
+    bytes: Vec<u8>,
+}
+
+impl Payload {
+    /// Wraps an arbitrary array of bytes into a Payload type.
+    pub fn new(bytes: Vec<u8>) -> Self {
+        Self { bytes }
+    }
+
+    /// Converts the Payload bytes into a Blob
+    ///
+    /// The payload_form indicates how payloads are interpreted. The form of a payload dictates what conversion, if any, must
+    /// be performed when creating a blob from the payload.
+    pub fn to_blob(&self, payload_form: PayloadForm) -> Blob {
+        let encoded_payload = EncodedPayload::new(&self);
+        let field_elements = encoded_payload.to_field_elements();
+
+        let blob_length_symbols = ((&field_elements).len() as u32).next_power_of_two();
+
+        let coeff_polynomial = match payload_form {
+            PayloadForm::Coeff => {
+                // the payload is already in coefficient form. no conversion needs to take place, since blobs are also in
+                // coefficient form
+                field_elements
+            }
+            PayloadForm::Eval => {
+                // the payload is in evaluation form, so we need to convert it to coeff form, since blobs are in coefficient form
+                let eval_poly = field_elements;
+                let coeff_poly = eval_to_coeff_poly(eval_poly, blob_length_symbols);
+                coeff_poly
+            }
+        };
+
+        Blob::from_polynomial(coeff_polynomial, blob_length_symbols)
+    }
+
+    /// Returns the bytes that underlie the payload, i.e. the unprocessed user data
+    pub fn serialize(&self) -> Vec<u8> {
+        self.bytes.clone()
+    }
+}
+
+/// Converts an eval_poly to a coeff_poly, using the IFFT operation
+///
+/// blob_length_symbols is required, to be able to choose the correct parameters when performing FFT
+fn eval_to_coeff_poly(eval_poly: Vec<Fr>, blob_length_symbols: u32) -> Vec<Fr> {
+    GeneralEvaluationDomain::<Fr>::new(blob_length_symbols as usize)
+        .unwrap()
+        .fft(&eval_poly)
+}


### PR DESCRIPTION
Implement `Payload` structure for the V2 client.

⚠️ This module lacks it's own tests and will rely on other modules to check it works as expected, this PR should be merged only after integration with them.