### PR TITLE
V2 Client: add e2e test

### DIFF
--- a/crates/rust-eigenda-v2-client/src/cert_verifier.rs
+++ b/crates/rust-eigenda-v2-client/src/cert_verifier.rs
@@ -1,6 +1,7 @@
 use std::str::FromStr;
 
 use alloy::{network::Ethereum, providers::RootProvider};
+use ethereum_types::H160;
 
 use crate::{
     contracts_bindings::IEigenDACertVerifier::{self},
@@ -19,11 +20,12 @@ pub struct CertVerifier {
 
 impl CertVerifier {
     /// Creates a new instance of CertVerifier receiving the address of the contract and the ETH RPC url.
-    pub fn new(address: String, rpc_url: String) -> Self {
+    pub fn new(address: H160, rpc_url: String) -> Self {
         let url = alloy::transports::http::reqwest::Url::from_str(&rpc_url).unwrap();
         let provider: RootProvider<Ethereum> = RootProvider::new_http(url);
 
-        let cert_verifier_address = alloy::primitives::Address::from_str(&address).unwrap();
+        let cert_verifier_address =
+            alloy::primitives::Address::from_str(&hex::encode(address)).unwrap();
         let cert_verifier_contract: IEigenDACertVerifier::IEigenDACertVerifierInstance<
             RootProvider,
         > = IEigenDACertVerifier::new(cert_verifier_address, provider);
@@ -93,6 +95,7 @@ mod tests {
             BatchHeaderV2, BlobCertificate, BlobCommitments, BlobHeader, BlobInclusionInfo,
             EigenDACert, NonSignerStakesAndSignature,
         },
+        tests::{CERT_VERIFIER_ADDRESS, HOLESKY_ETH_RPC_URL},
     };
 
     fn get_test_eigenda_cert() -> EigenDACert {
@@ -282,9 +285,8 @@ mod tests {
 
     #[tokio::test]
     async fn test_verify_cert() {
-        let address = "0xFe52fE1940858DCb6e12153E2104aD0fDFbE1162".to_string();
-        let rpc_url = "https://ethereum-holesky-rpc.publicnode.com".to_string();
-        let cert_verifier = CertVerifier::new(address, rpc_url);
+        let cert_verifier =
+            CertVerifier::new(CERT_VERIFIER_ADDRESS, HOLESKY_ETH_RPC_URL.to_string());
         let res = cert_verifier.verify_cert_v2(&get_test_eigenda_cert()).await;
         assert!(res.is_ok())
     }

--- a/crates/rust-eigenda-v2-client/src/core/eigenda_cert.rs
+++ b/crates/rust-eigenda-v2-client/src/core/eigenda_cert.rs
@@ -605,6 +605,7 @@ mod test {
                 Attestation, BlobInclusionInfo as BlobInclusionInfoProto, SignedBatch,
             },
         },
+        tests::{CERT_VERIFIER_ADDRESS, HOLESKY_ETH_RPC_URL},
     };
 
     use super::{BlobStatusReply, EigenDACert, NonSignerStakesAndSignature};
@@ -1077,9 +1078,8 @@ mod test {
         let expected_eigenda_cert = get_test_eigenda_cert();
         assert_eq!(expected_eigenda_cert, eigenda_cert);
 
-        let address = "0xFe52fE1940858DCb6e12153E2104aD0fDFbE1162".to_string();
-        let rpc_url = "https://ethereum-holesky-rpc.publicnode.com".to_string();
-        let cert_verifier = CertVerifier::new(address, rpc_url);
+        let cert_verifier =
+            CertVerifier::new(CERT_VERIFIER_ADDRESS, HOLESKY_ETH_RPC_URL.to_string());
         let res = cert_verifier.verify_cert_v2(&eigenda_cert).await;
         assert!(res.is_ok())
     }

--- a/crates/rust-eigenda-v2-client/src/core/eigenda_cert.rs
+++ b/crates/rust-eigenda-v2-client/src/core/eigenda_cert.rs
@@ -1079,7 +1079,7 @@ mod test {
         assert_eq!(expected_eigenda_cert, eigenda_cert);
 
         let cert_verifier =
-            CertVerifier::new(CERT_VERIFIER_ADDRESS, HOLESKY_ETH_RPC_URL.to_string());
+            CertVerifier::new(CERT_VERIFIER_ADDRESS, HOLESKY_ETH_RPC_URL.to_string()).unwrap();
         let res = cert_verifier.verify_cert_v2(&eigenda_cert).await;
         assert!(res.is_ok())
     }

--- a/crates/rust-eigenda-v2-client/src/disperser_client.rs
+++ b/crates/rust-eigenda-v2-client/src/disperser_client.rs
@@ -52,7 +52,7 @@ impl DisperserClientConfig {
     }
 }
 
-pub struct DisperserClient {
+pub(crate) struct DisperserClient {
     signer: LocalBlobRequestSigner,
     rpc_client: disperser_client::DisperserClient<tonic::transport::Channel>,
     accountant: Accountant,
@@ -60,7 +60,7 @@ pub struct DisperserClient {
 
 // todo: add locks
 impl DisperserClient {
-    pub async fn new(config: DisperserClientConfig) -> Result<Self, DisperseError> {
+    pub(crate) async fn new(config: DisperserClientConfig) -> Result<Self, DisperseError> {
         let mut endpoint = Channel::from_shared(config.disperser_rpc.clone())
             .map_err(|_| DisperseError::InvalidURI(config.disperser_rpc.clone()))?;
         if config.use_secure_grpc_flag {
@@ -88,7 +88,7 @@ impl DisperserClient {
         Ok(disperser)
     }
 
-    pub async fn disperse_blob(
+    pub(crate) async fn disperse_blob(
         &mut self,
         data: &[u8],
         blob_version: u16,
@@ -177,7 +177,7 @@ impl DisperserClient {
     }
 
     /// Returns the status of a blob with the given blob key.
-    pub async fn blob_status(
+    pub(crate) async fn blob_status(
         &mut self,
         blob_key: &BlobKey,
     ) -> Result<BlobStatusReply, DisperseError> {
@@ -193,7 +193,7 @@ impl DisperserClient {
     }
 
     /// Returns the payment state of the disperser client
-    pub async fn payment_state(&mut self) -> Result<GetPaymentStateReply, DisperseError> {
+    pub(crate) async fn payment_state(&mut self) -> Result<GetPaymentStateReply, DisperseError> {
         let account_id = self.signer.account_id().encode_hex();
         let timestamp = SystemTime::now().duration_since(UNIX_EPOCH)?.as_nanos();
         let signature = self.signer.sign_payment_state_request(timestamp as u64)?;
@@ -210,7 +210,7 @@ impl DisperserClient {
             .map_err(DisperseError::FailedRPC)
     }
 
-    pub async fn blob_commitment(
+    pub(crate) async fn blob_commitment(
         &mut self,
         data: &[u8],
     ) -> Result<BlobCommitmentReply, DisperseError> {

--- a/crates/rust-eigenda-v2-client/src/disperser_client.rs
+++ b/crates/rust-eigenda-v2-client/src/disperser_client.rs
@@ -229,27 +229,22 @@ impl DisperserClient {
 #[cfg(test)]
 mod tests {
 
-    use crate::disperser_client::DisperserClient;
+    use crate::{
+        disperser_client::DisperserClient,
+        tests::{get_test_private_key, HOLESKY_DISPERSER_RPC_URL},
+    };
 
     use super::DisperserClientConfig;
 
-    use dotenv::dotenv;
     use serial_test::serial;
-    use std::env;
 
     #[ignore = "depends on external RPC"]
     #[tokio::test]
     #[serial]
     async fn test_disperse_non_secure() {
-        dotenv().ok();
-
-        // Set your private key in .env file
-        let private_key: String =
-            env::var("SIGNER_PRIVATE_KEY").expect("SIGNER_PRIVATE_KEY must be set");
-
         let config = DisperserClientConfig {
-            disperser_rpc: "https://disperser-testnet-holesky.eigenda.xyz".to_string(),
-            private_key,
+            disperser_rpc: HOLESKY_DISPERSER_RPC_URL.to_string(),
+            private_key: get_test_private_key(),
             use_secure_grpc_flag: false,
         };
         let mut client = DisperserClient::new(config).await.unwrap();
@@ -265,15 +260,9 @@ mod tests {
     #[tokio::test]
     #[serial]
     async fn test_disperse_secure() {
-        dotenv().ok();
-
-        // Set your private key in .env file
-        let private_key: String =
-            env::var("SIGNER_PRIVATE_KEY").expect("SIGNER_PRIVATE_KEY must be set");
-
         let config = DisperserClientConfig {
-            disperser_rpc: "https://disperser-preprod-holesky.eigenda.xyz".to_string(),
-            private_key,
+            disperser_rpc: HOLESKY_DISPERSER_RPC_URL.to_string(),
+            private_key: get_test_private_key(),
             use_secure_grpc_flag: true,
         };
         let mut client = DisperserClient::new(config).await.unwrap();
@@ -288,15 +277,9 @@ mod tests {
     #[tokio::test]
     #[serial]
     async fn test_double_disperse_secure() {
-        dotenv().ok();
-
-        // Set your private key in .env file
-        let private_key: String =
-            env::var("SIGNER_PRIVATE_KEY").expect("SIGNER_PRIVATE_KEY must be set");
-
         let config = DisperserClientConfig {
-            disperser_rpc: "https://disperser-preprod-holesky.eigenda.xyz".to_string(),
-            private_key,
+            disperser_rpc: HOLESKY_DISPERSER_RPC_URL.to_string(),
+            private_key: get_test_private_key(),
             use_secure_grpc_flag: true,
         };
         let mut client = DisperserClient::new(config).await.unwrap();

--- a/crates/rust-eigenda-v2-client/src/errors.rs
+++ b/crates/rust-eigenda-v2-client/src/errors.rs
@@ -1,4 +1,5 @@
 use ark_bn254::{Fr, G1Affine};
+use ethereum_types::H160;
 use rust_kzg_bn254_primitives::errors::KzgError;
 
 use crate::relay_client::RelayKey;
@@ -210,4 +211,8 @@ pub enum CertVerifierError {
     Conversion(#[from] ConversionError),
     #[error(transparent)]
     Alloy(#[from] alloy_contract::Error),
+    #[error("Invalid ETH rpc: {0}")]
+    InvalidEthRpc(String),
+    #[error("Invalid cert verifier contract address: {0}")]
+    InvalidCertVerifierAddress(H160),
 }

--- a/crates/rust-eigenda-v2-client/src/lib.rs
+++ b/crates/rust-eigenda-v2-client/src/lib.rs
@@ -7,11 +7,15 @@ pub mod disperser_client;
 pub mod errors;
 pub mod eth_client;
 pub mod payload_disperser;
+pub mod payloadretrieval;
 pub mod prover;
 pub mod relay_client;
 pub mod retrieval_client;
 pub mod utils;
 pub mod verifier;
+
+#[cfg(test)]
+mod tests;
 
 #[allow(clippy::all)]
 pub(crate) mod generated {

--- a/crates/rust-eigenda-v2-client/src/payload_disperser.rs
+++ b/crates/rust-eigenda-v2-client/src/payload_disperser.rs
@@ -1,3 +1,5 @@
+use ethereum_types::H160;
+
 use crate::{
     cert_verifier::CertVerifier,
     core::{eigenda_cert::EigenDACert, BlobKey, Payload, PayloadForm},
@@ -8,10 +10,10 @@ use crate::{
 
 #[derive(Clone)]
 pub struct PayloadDisperserConfig {
-    polynomial_form: PayloadForm,
-    blob_version: u16,
-    cert_verifier_address: String,
-    eth_rpc_url: String,
+    pub polynomial_form: PayloadForm,
+    pub blob_version: u16,
+    pub cert_verifier_address: H160,
+    pub eth_rpc_url: String,
 }
 
 /// PayloadDisperser provides the ability to disperse payloads to EigenDA via a Disperser grpc service.
@@ -30,7 +32,7 @@ impl PayloadDisperser {
     ) -> Result<Self, PayloadDisperserError> {
         let disperser_client = DisperserClient::new(disperser_config).await?;
         let cert_verifier = CertVerifier::new(
-            payload_config.cert_verifier_address.clone(),
+            payload_config.cert_verifier_address,
             payload_config.eth_rpc_url.clone(),
         );
         let required_quorums = cert_verifier.quorum_numbers_required().await?;
@@ -135,33 +137,28 @@ mod tests {
         core::{Payload, PayloadForm},
         disperser_client::DisperserClientConfig,
         payload_disperser::{PayloadDisperser, PayloadDisperserConfig},
+        tests::{
+            get_test_private_key, CERT_VERIFIER_ADDRESS, HOLESKY_DISPERSER_RPC_URL,
+            HOLESKY_ETH_RPC_URL,
+        },
     };
-
-    use dotenv::dotenv;
-    use std::env;
 
     #[ignore = "depends on external RPC"]
     #[tokio::test]
     async fn test_disperse_payload() {
-        dotenv().ok();
-
         let timeout = tokio::time::Duration::from_secs(180);
 
-        // Set your private key in .env file
-        let private_key: String =
-            env::var("SIGNER_PRIVATE_KEY").expect("SIGNER_PRIVATE_KEY must be set");
-
         let disperser_config = DisperserClientConfig {
-            disperser_rpc: "https://disperser-testnet-holesky.eigenda.xyz".to_string(),
-            private_key,
+            disperser_rpc: HOLESKY_DISPERSER_RPC_URL.to_string(),
+            private_key: get_test_private_key(),
             use_secure_grpc_flag: false,
         };
 
         let payload_config = PayloadDisperserConfig {
             polynomial_form: PayloadForm::Coeff,
             blob_version: 0,
-            cert_verifier_address: "0xFe52fE1940858DCb6e12153E2104aD0fDFbE1162".to_string(),
-            eth_rpc_url: "https://ethereum-holesky-rpc.publicnode.com".to_string(),
+            cert_verifier_address: CERT_VERIFIER_ADDRESS,
+            eth_rpc_url: HOLESKY_ETH_RPC_URL.to_string(),
         };
 
         let mut payload_disperser = PayloadDisperser::new(disperser_config, payload_config)

--- a/crates/rust-eigenda-v2-client/src/payload_disperser.rs
+++ b/crates/rust-eigenda-v2-client/src/payload_disperser.rs
@@ -34,7 +34,7 @@ impl PayloadDisperser {
         let cert_verifier = CertVerifier::new(
             payload_config.cert_verifier_address,
             payload_config.eth_rpc_url.clone(),
-        );
+        )?;
         let required_quorums = cert_verifier.quorum_numbers_required().await?;
         Ok(PayloadDisperser {
             disperser_client,

--- a/crates/rust-eigenda-v2-client/src/tests.rs
+++ b/crates/rust-eigenda-v2-client/src/tests.rs
@@ -1,0 +1,139 @@
+use dotenv::dotenv;
+use ethereum_types::H160;
+use std::{env, str::FromStr, sync::Arc, time::Duration};
+use tokio::sync::Mutex;
+use url::Url;
+
+use crate::{
+    core::{eigenda_cert::EigenDACert, BlobKey, Payload, PayloadForm},
+    disperser_client::DisperserClientConfig,
+    eth_client::EthClient,
+    payload_disperser::{PayloadDisperser, PayloadDisperserConfig},
+    payloadretrieval::relay_payload_retriever::{
+        RelayPayloadRetriever, RelayPayloadRetrieverConfig, SRSConfig,
+    },
+    relay_client::RelayClient,
+    utils::SecretUrl,
+};
+
+const TEST_BLOB_FINALIZATION_TIMEOUT: u64 = 180;
+const TEST_PAYLOAD_DATA: &[u8] = &[1, 2, 3, 4, 5];
+pub const HOLESKY_ETH_RPC_URL: &str = "https://ethereum-holesky-rpc.publicnode.com";
+pub const HOLESKY_DISPERSER_RPC_URL: &str = "https://disperser-testnet-holesky.eigenda.xyz";
+pub const HOLESKY_RELAY_REGISTRY_ADDRESS: H160 = H160([
+    0xac, 0x8c, 0x6c, 0x7e, 0xe7, 0x57, 0x29, 0x75, 0x45, 0x4e, 0x2f, 0x0b, 0x5c, 0x72, 0x0f, 0x9e,
+    0x74, 0x98, 0x92, 0x54,
+]);
+pub const CERT_VERIFIER_ADDRESS: H160 = H160([
+    0xfe, 0x52, 0xfe, 0x19, 0x40, 0x85, 0x8d, 0xcb, 0x6e, 0x12, 0x15, 0x3e, 0x21, 0x04, 0xad, 0x0f,
+    0xdf, 0xbe, 0x11, 0x62,
+]);
+
+pub fn get_test_private_key() -> String {
+    dotenv().ok();
+    env::var("SIGNER_PRIVATE_KEY").expect("SIGNER_PRIVATE_KEY must be set")
+}
+
+fn get_test_disperser_client_config() -> DisperserClientConfig {
+    DisperserClientConfig {
+        disperser_rpc: HOLESKY_DISPERSER_RPC_URL.to_string(),
+        private_key: get_test_private_key(),
+        use_secure_grpc_flag: false,
+    }
+}
+
+fn get_test_payload_disperser_config() -> PayloadDisperserConfig {
+    PayloadDisperserConfig {
+        polynomial_form: PayloadForm::Coeff,
+        blob_version: 0,
+        cert_verifier_address: CERT_VERIFIER_ADDRESS,
+        eth_rpc_url: HOLESKY_ETH_RPC_URL.to_string(),
+    }
+}
+
+pub fn get_relay_payload_retriever_test_config() -> RelayPayloadRetrieverConfig {
+    RelayPayloadRetrieverConfig {
+        payload_form: PayloadForm::Coeff,
+        retrieval_timeout_secs: Duration::from_secs(10),
+    }
+}
+
+pub fn get_srs_test_config() -> SRSConfig {
+    SRSConfig {
+        source_path: "../../resources/g1.point".to_string(),
+        order: 42,
+        points_to_load: 42,
+    }
+}
+
+pub fn get_relay_client_test_config() -> crate::relay_client::RelayClientConfig {
+    crate::relay_client::RelayClientConfig {
+        max_grpc_message_size: 9999999,
+        relay_clients_keys: vec![1, 2],
+        relay_registry_address: HOLESKY_RELAY_REGISTRY_ADDRESS,
+    }
+}
+
+pub async fn get_test_relay_client() -> RelayClient {
+    let eth_client = EthClient::new(SecretUrl::new(Url::from_str(HOLESKY_ETH_RPC_URL).unwrap()));
+    let eth_client = Arc::new(Mutex::new(eth_client));
+
+    RelayClient::new(get_relay_client_test_config(), eth_client)
+        .await
+        .unwrap()
+}
+
+async fn wait_for_blob_finalization_and_verification(
+    payload_disperser: &mut PayloadDisperser,
+    blob_key: &BlobKey,
+) -> EigenDACert {
+    let timeout = tokio::time::Duration::from_secs(TEST_BLOB_FINALIZATION_TIMEOUT);
+
+    let start_time = tokio::time::Instant::now();
+    loop {
+        let inclusion_data = payload_disperser
+            .get_inclusion_data(blob_key)
+            .await
+            .unwrap();
+        match inclusion_data {
+            Some(cert) => {
+                return cert;
+            }
+            None => {
+                let elapsed = start_time.elapsed();
+                assert!(elapsed < timeout, "Timeout waiting for inclusion data");
+                tokio::time::sleep(tokio::time::Duration::from_secs(1)).await;
+            }
+        }
+    }
+}
+
+#[ignore = "depends on external RPC"]
+#[tokio::test]
+async fn test_disperse_and_retrieve_blob() {
+    let payload_data = TEST_PAYLOAD_DATA.to_vec();
+    let payload = Payload::new(payload_data.clone());
+
+    // First we disperse a blob using a Payload Disperser
+    let mut payload_disperser = PayloadDisperser::new(
+        get_test_disperser_client_config(),
+        get_test_payload_disperser_config(),
+    )
+    .await
+    .unwrap();
+    let blob_key = payload_disperser.send_payload(payload).await.unwrap();
+
+    // Then we wait for the blob to be finalized and verified
+    let eigenda_cert =
+        wait_for_blob_finalization_and_verification(&mut payload_disperser, &blob_key).await;
+
+    // Finally we retrieve the blob using a Relay Payload Retriever
+    let relay_config = get_relay_payload_retriever_test_config();
+    let srs_config = get_srs_test_config();
+    let relay_client = get_test_relay_client().await;
+    let mut client = RelayPayloadRetriever::new(relay_config, srs_config, relay_client).unwrap();
+
+    let result = client.get_payload(eigenda_cert).await;
+    let retrieved_payload = result.unwrap().serialize();
+    assert_eq!(payload_data, retrieved_payload);
+}

--- a/crates/rust-eigenda-v2-client/src/utils.rs
+++ b/crates/rust-eigenda-v2-client/src/utils.rs
@@ -88,17 +88,3 @@ pub(crate) fn fr_array_from_bytes(input_data: &[u8]) -> Vec<Fr> {
     }
     output_elements
 }
-
-#[cfg(test)]
-pub fn relay_client_test_config() -> crate::relay_client::RelayClientConfig {
-    use std::str::FromStr;
-
-    crate::relay_client::RelayClientConfig {
-        max_grpc_message_size: 9999999,
-        relay_clients_keys: vec![1, 2],
-        relay_registry_address: ethereum_types::H160::from_str(
-            "0xaC8C6C7Ee7572975454E2f0b5c720f9E74989254",
-        )
-        .unwrap(),
-    }
-}


### PR DESCRIPTION
- Add test that disperses, verifies and retrieves a blob, using the payload disperser and relay payload retriever
- Replace some common shared variables amongs tests with constants