### PR TITLE
V2 Client: change struct & function visibilities

### DIFF
--- a/crates/rust-eigenda-v2-client/src/disperser_client.rs
+++ b/crates/rust-eigenda-v2-client/src/disperser_client.rs
@@ -60,7 +60,7 @@ impl DisperserClientConfig {
 /// DisperserClient is a client for the entire disperser subsystem.
 ///
 /// This struct is a low level implementation and should not be used directly,
-/// use a high level abstraction to interact with it (`PayloadDisperser`).
+/// use a high level abstraction to interact with it ([`PayloadDisperser`]).
 #[derive(Debug, Clone)]
 pub struct DisperserClient {
     signer: LocalBlobRequestSigner,

--- a/crates/rust-eigenda-v2-client/src/disperser_client.rs
+++ b/crates/rust-eigenda-v2-client/src/disperser_client.rs
@@ -57,8 +57,12 @@ impl DisperserClientConfig {
     }
 }
 
+/// DisperserClient is a client for the entire disperser subsystem.
+///
+/// This struct is a low level implementation and should not be used directly,
+/// use a high level abstraction to interact with it (`PayloadDisperser`).
 #[derive(Debug, Clone)]
-pub(crate) struct DisperserClient {
+pub struct DisperserClient {
     signer: LocalBlobRequestSigner,
     rpc_client: Arc<Mutex<disperser_client::DisperserClient<tonic::transport::Channel>>>,
     accountant: Arc<Mutex<Accountant>>,
@@ -66,7 +70,7 @@ pub(crate) struct DisperserClient {
 
 // todo: add locks
 impl DisperserClient {
-    pub(crate) async fn new(config: DisperserClientConfig) -> Result<Self, DisperseError> {
+    pub async fn new(config: DisperserClientConfig) -> Result<Self, DisperseError> {
         let mut endpoint = Channel::from_shared(config.disperser_rpc.clone())
             .map_err(|_| DisperseError::InvalidURI(config.disperser_rpc.clone()))?;
         if config.use_secure_grpc_flag {
@@ -94,7 +98,7 @@ impl DisperserClient {
         Ok(disperser)
     }
 
-    pub(crate) async fn disperse_blob(
+    pub async fn disperse_blob(
         &self,
         data: &[u8],
         blob_version: u16,
@@ -190,10 +194,7 @@ impl DisperserClient {
     }
 
     /// Returns the status of a blob with the given blob key.
-    pub(crate) async fn blob_status(
-        &self,
-        blob_key: &BlobKey,
-    ) -> Result<BlobStatusReply, DisperseError> {
+    pub async fn blob_status(&self, blob_key: &BlobKey) -> Result<BlobStatusReply, DisperseError> {
         let request = BlobStatusRequest {
             blob_key: blob_key.to_bytes().to_vec(),
         };
@@ -208,7 +209,7 @@ impl DisperserClient {
     }
 
     /// Returns the payment state of the disperser client
-    pub(crate) async fn payment_state(&self) -> Result<GetPaymentStateReply, DisperseError> {
+    pub async fn payment_state(&self) -> Result<GetPaymentStateReply, DisperseError> {
         let account_id = self.signer.account_id().encode_hex();
         let timestamp = SystemTime::now().duration_since(UNIX_EPOCH)?.as_nanos();
         let signature = self.signer.sign_payment_state_request(timestamp as u64)?;
@@ -227,10 +228,7 @@ impl DisperserClient {
             .map_err(DisperseError::FailedRPC)
     }
 
-    pub(crate) async fn blob_commitment(
-        &self,
-        data: &[u8],
-    ) -> Result<BlobCommitmentReply, DisperseError> {
+    pub async fn blob_commitment(&self, data: &[u8]) -> Result<BlobCommitmentReply, DisperseError> {
         let request = BlobCommitmentRequest {
             blob: data.to_vec(),
         };

--- a/crates/rust-eigenda-v2-client/src/payloadretrieval/relay_payload_retriever.rs
+++ b/crates/rust-eigenda-v2-client/src/payloadretrieval/relay_payload_retriever.rs
@@ -252,7 +252,7 @@ mod tests {
             signed_quorum_numbers: vec![0, 1],
         }
     }
-    
+
     #[ignore = "depends on external RPC"]
     #[tokio::test]
     async fn get_payload_from_relay() {

--- a/crates/rust-eigenda-v2-client/src/relay_client.rs
+++ b/crates/rust-eigenda-v2-client/src/relay_client.rs
@@ -23,9 +23,11 @@ pub struct RelayClientConfig {
     pub(crate) eth_rpc_url: SecretUrl,
 }
 
-// RelayClient is a client for the entire relay subsystem.
-//
-// It is a wrapper around a collection of grpc relay clients, which are used to interact with individual relays.
+/// RelayClient is a client for the entire relay subsystem.
+///
+/// It is a wrapper around a collection of grpc relay clients, which are used to interact with individual relays.
+/// This struct is a low level implementation and should not be used directly,
+/// use a high level abstraction to interact with it (`RelayPayloadRetriever`).
 pub struct RelayClient {
     rpc_clients: HashMap<RelayKey, RpcRelayClient<tonic::transport::Channel>>,
 }

--- a/crates/rust-eigenda-v2-client/src/relay_client.rs
+++ b/crates/rust-eigenda-v2-client/src/relay_client.rs
@@ -27,7 +27,7 @@ pub struct RelayClientConfig {
 ///
 /// It is a wrapper around a collection of grpc relay clients, which are used to interact with individual relays.
 /// This struct is a low level implementation and should not be used directly,
-/// use a high level abstraction to interact with it (`RelayPayloadRetriever`).
+/// use a high level abstraction to interact with it ([`RelayPayloadRetriever`]).
 pub struct RelayClient {
     rpc_clients: HashMap<RelayKey, RpcRelayClient<tonic::transport::Channel>>,
 }


### PR DESCRIPTION
- Downgrade visibility of functions inside of `commitment_utils` from `pub` to `pub(crate)` as they are not intended to be used externally.
- Make `DisperserClient` `pub` so it matches go's visibility, add a disclaimer noticing that's it's not intended to be used directly in most cases.