### PR TITLE
V2 Client: change deps to crates.io

### DIFF
--- a/crates/rust-eigenda-v2-client/Cargo.toml
+++ b/crates/rust-eigenda-v2-client/Cargo.toml
@@ -9,13 +9,14 @@ repository = "https://github.com/Layr-Labs/eigenda-client-rs"
 description = "EigenDA Client"
 license = "MIT OR Apache-2.0"
 exclude = [
-  # Excluded because g1.point is 32MiB and max crates.io package size is 10MiB.
-  # Users should download the SRS points themselves from the repo or elsewhere.
-  "../../resources/*",
+    # Excluded because g1.point is 32MiB and max crates.io package size is 10MiB.
+    # Users should download the SRS points themselves from the repo or elsewhere.
+    "../../resources/*",
 ]
 
 [dependencies]
-rust-eigenda-signers = { workspace = true, features = ["ethers-signer"] }
+rust-eigenda-signers = { version = "0.1.4", features = ["ethers-signer"] }
+rust-eigenda-v2-common = "0.1.0"
 rand = { workspace = true }
 bytes = { workspace = true }
 reqwest = { workspace = true }
@@ -47,7 +48,6 @@ ark-ec = { workspace = true }
 sha2 = { workspace = true }
 bincode = { workspace = true }
 ethers = { workspace = true }
-rust-eigenda-v2-common = { path = "../rust-eigenda-v2-common" }
 
 [dev-dependencies]
 dotenv = { workspace = true }


### PR DESCRIPTION
Update `Cargo.toml` of `rust-eigenda-v2-client` to no longer use members from the same workspace and instead use it's crates.io counterparts. This in necessary in order to publish the `rust-eigenda-v2-client` crate itself.