### PR TITLE
V2 Client: update toml

### DIFF
--- a/crates/rust-eigenda-v2-client/Cargo.toml
+++ b/crates/rust-eigenda-v2-client/Cargo.toml
@@ -15,14 +15,8 @@ exclude = [
 ]
 
 [dependencies]
-# rust-eigenda-signers = { version = "0.1.4", features = ["ethers-signer"] }
-# rust-eigenda-v2-common = "0.1.0"
-
-# TODO: replace with crates.io once published
-rust-eigenda-v2-common = { git = "https://github.com/Layr-labs/eigenda-client-rs/", branch = "improved-docs" }
-rust-eigenda-signers = { git = "https://github.com/Layr-labs/eigenda-client-rs/", branch = "improved-docs", features = [
-    "ethers-signer",
-] }
+rust-eigenda-signers = { version = "0.1.5", features = ["ethers-signer"] }
+rust-eigenda-v2-common = "0.1.1"
 
 rand = { workspace = true }
 bytes = { workspace = true }


### PR DESCRIPTION
- Update cargo toml of v2 client to use crates.io deps after [latest PR merge](https://github.com/Layr-Labs/eigenda-client-rs/pull/88).