### PR TITLE
Rename inclusion data for cert

### DIFF
--- a/crates/rust-eigenda-v2-client/README.md
+++ b/crates/rust-eigenda-v2-client/README.md
@@ -85,7 +85,7 @@ async fn main() {
     tokio::time::sleep(tokio::time::Duration::from_secs(60 * 5)).await;
 
     let inclusion_data = payload_disperser
-        .get_inclusion_data(&blob_key)
+        .get_cert(&blob_key)
         .await
         .unwrap();
     let eigenda_cert = inclusion_data.unwrap();

--- a/crates/rust-eigenda-v2-client/README.md
+++ b/crates/rust-eigenda-v2-client/README.md
@@ -84,11 +84,11 @@ async fn main() {
     // sleep so we let the dispersal process complete
     tokio::time::sleep(tokio::time::Duration::from_secs(60 * 5)).await;
 
-    let inclusion_data = payload_disperser
+    let cert = payload_disperser
         .get_cert(&blob_key)
         .await
         .unwrap();
-    let eigenda_cert = inclusion_data.unwrap();
+    let eigenda_cert = cert.unwrap();
 
     // Retriever
     let signer = Signer::new(private_key);

--- a/crates/rust-eigenda-v2-client/src/lib.rs
+++ b/crates/rust-eigenda-v2-client/src/lib.rs
@@ -153,8 +153,8 @@ mod tests {
 
         let start_time = tokio::time::Instant::now();
         loop {
-            let inclusion_data = payload_disperser.get_cert(blob_key).await.unwrap();
-            match inclusion_data {
+            let cert = payload_disperser.get_cert(blob_key).await.unwrap();
+            match cert {
                 Some(cert) => {
                     return cert;
                 }

--- a/crates/rust-eigenda-v2-client/src/lib.rs
+++ b/crates/rust-eigenda-v2-client/src/lib.rs
@@ -153,10 +153,7 @@ mod tests {
 
         let start_time = tokio::time::Instant::now();
         loop {
-            let inclusion_data = payload_disperser
-                .get_inclusion_data(blob_key)
-                .await
-                .unwrap();
+            let inclusion_data = payload_disperser.get_cert(blob_key).await.unwrap();
             match inclusion_data {
                 Some(cert) => {
                     return cert;

--- a/crates/rust-eigenda-v2-client/src/payload_disperser.rs
+++ b/crates/rust-eigenda-v2-client/src/payload_disperser.rs
@@ -197,8 +197,8 @@ mod tests {
         let mut finished = false;
         let start_time = tokio::time::Instant::now();
         while !finished {
-            let inclusion_data = payload_disperser.get_cert(&blob_key).await.unwrap();
-            match inclusion_data {
+            let cert = payload_disperser.get_cert(&blob_key).await.unwrap();
+            match cert {
                 Some(cert) => {
                     println!("Inclusion data: {:?}", cert);
                     finished = true;

--- a/crates/rust-eigenda-v2-client/src/payload_disperser.rs
+++ b/crates/rust-eigenda-v2-client/src/payload_disperser.rs
@@ -92,7 +92,7 @@ impl<S> PayloadDisperser<S> {
 
     /// Retrieves the inclusion data for a given blob key
     /// If the requested blob is still not complete, returns None
-    pub async fn get_inclusion_data(
+    pub async fn get_cert(
         &self,
         blob_key: &BlobKey,
     ) -> Result<Option<EigenDACert>, EigenClientError>
@@ -197,10 +197,7 @@ mod tests {
         let mut finished = false;
         let start_time = tokio::time::Instant::now();
         while !finished {
-            let inclusion_data = payload_disperser
-                .get_inclusion_data(&blob_key)
-                .await
-                .unwrap();
+            let inclusion_data = payload_disperser.get_cert(&blob_key).await.unwrap();
             match inclusion_data {
                 Some(cert) => {
                     println!("Inclusion data: {:?}", cert);

--- a/crates/rust-eigenda-v2-common/Cargo.toml
+++ b/crates/rust-eigenda-v2-common/Cargo.toml
@@ -3,7 +3,7 @@
 # We will remove the prefix and publish as new crates once we combine all of these repos
 # and move them into the eigenda monorepo.
 name = "rust-eigenda-v2-common"
-version = "0.1.1"
+version = "0.1.2"
 edition = "2021"
 repository = "https://github.com/Layr-Labs/eigenda-client-rs"
 description = "EigenDA Common"


### PR DESCRIPTION
Rename get inclusion data function for get cert in order to make the client agnostic to zksync's terminology