### PR TITLE
Up V2 version

### DIFF
--- a/crates/rust-eigenda-v2-client/Cargo.toml
+++ b/crates/rust-eigenda-v2-client/Cargo.toml
@@ -3,7 +3,7 @@
 # We will remove the prefix and publish as new crates once we combine all of these repos
 # and move them into the eigenda monorepo.
 name = "rust-eigenda-v2-client"
-version = "0.1.1"
+version = "0.1.2"
 edition = "2021"
 repository = "https://github.com/Layr-Labs/eigenda-client-rs"
 description = "EigenDA Client"
@@ -16,7 +16,7 @@ exclude = [
 
 [dependencies]
 rust-eigenda-signers = { version = "0.1.5", features = ["ethers-signer"] }
-rust-eigenda-v2-common = "0.1.1"
+rust-eigenda-v2-common = "0.1.2"
 
 rand = { workspace = true }
 bytes = { workspace = true }

--- a/crates/rust-eigenda-v2-client/README.md
+++ b/crates/rust-eigenda-v2-client/README.md
@@ -111,5 +111,5 @@ async fn main() {
 
 ```toml
 [dependencies]
-rust-eigenda-v2-client = "0.1.1"
+rust-eigenda-v2-client = "0.1"
 ```

--- a/crates/rust-eigenda-v2-common/README.md
+++ b/crates/rust-eigenda-v2-common/README.md
@@ -14,5 +14,5 @@ Crate with definition of multiple types used in the v2 client of EigenDA.
 
 ```toml
 [dependencies]
-rust-eigenda-v2-common = "0.1.1"
+rust-eigenda-v2-common = "0.1"
 ```


### PR DESCRIPTION
Up v2 version to 0.1.2, it renames get inclusion data for get cert to make it zksync agnostic