### PR TITLE
V1: Check Finality

### DIFF
--- a/crates/rust-eigenda-client/Cargo.toml
+++ b/crates/rust-eigenda-client/Cargo.toml
@@ -5,7 +5,7 @@
 name = "rust-eigenda-client"
 repository = "https://github.com/Layr-Labs/eigenda-client-rs"
 description = "EigenDA Client"
-version = "0.1.5"
+version = "0.1.6"
 edition = "2021"
 license = "MIT OR Apache-2.0"
 exclude = [

--- a/crates/rust-eigenda-client/src/client.rs
+++ b/crates/rust-eigenda-client/src/client.rs
@@ -63,6 +63,15 @@ impl<S> EigenClient<S> {
         self.client.get_blob_info(blob_id).await
     }
 
+    /// Checks if the blob is included in EigenDA
+    pub async fn check_finality(&self, blob_id: &str) -> Result<bool, EigenClientError> {
+        let blob_info = self
+            .client
+            .try_get_inclusion_data(blob_id.to_string())
+            .await?;
+        Ok(blob_info.is_some())
+    }
+
     /// Returns the blob size limit
     pub fn blob_size_limit(&self) -> Option<usize> {
         Some(RawEigenClient::<S>::blob_size_limit())

--- a/crates/rust-eigenda-client/src/sdk.rs
+++ b/crates/rust-eigenda-client/src/sdk.rs
@@ -347,7 +347,7 @@ impl<S> RawEigenClient<S> {
         }
     }
 
-    async fn try_get_inclusion_data(
+    pub(crate) async fn try_get_inclusion_data(
         &self,
         request_id: String,
     ) -> Result<Option<DisperserBlobInfo>, EigenClientError> {


### PR DESCRIPTION
This PR adds a check finality function to the V1 client, that returns a boolean that indicates whether the blob has finished dispersal on EigenDA.