### PR TITLE
V2 Client: fix required quorums retrieval location

### DIFF
--- a/crates/rust-eigenda-client/src/errors.rs
+++ b/crates/rust-eigenda-client/src/errors.rs
@@ -14,7 +14,7 @@ pub enum EigenClientError {
     #[error(transparent)]
     Communication(#[from] CommunicationError),
     #[error(transparent)]
-    BlobStatus(#[from] BlobStatusError),
+    BlobStatus(#[from] Box<BlobStatusError>),
     #[error(transparent)]
     Conversion(#[from] ConversionError),
     #[error(transparent)]
@@ -69,6 +69,12 @@ pub enum BlobStatusError {
     Prost(#[from] prost::DecodeError),
     #[error(transparent)]
     Status(#[from] Status),
+}
+
+impl From<BlobStatusError> for EigenClientError {
+    fn from(err: BlobStatusError) -> Self {
+        EigenClientError::BlobStatus(Box::new(err))
+    }
 }
 
 /// Errors specific to conversion

--- a/crates/rust-eigenda-signers/src/signers/ethers.rs
+++ b/crates/rust-eigenda-signers/src/signers/ethers.rs
@@ -131,7 +131,6 @@ where
     }
 
     /// Sets the signer's chain id
-    #[must_use]
     fn with_chain_id<C: Into<u64>>(mut self, chain_id: C) -> Self {
         self.chain_id = chain_id.into();
         self

--- a/crates/rust-eigenda-v2-client/src/disperser_client.rs
+++ b/crates/rust-eigenda-v2-client/src/disperser_client.rs
@@ -183,7 +183,7 @@ impl<S> DisperserClient<S> {
             .disperse_blob(disperse_request)
             .await
             .map(|response| response.into_inner())
-            .map_err(DisperseError::FailedRPC)?;
+            .map_err(|e| DisperseError::FailedRPC(Box::new(e)))?;
 
         if BlobKey::compute_blob_key(&blob_header)?.to_bytes().to_vec() != reply.blob_key {
             return Err(DisperseError::BlobKeyMismatch);
@@ -221,7 +221,7 @@ impl<S> DisperserClient<S> {
             .get_blob_status(request)
             .await
             .map(|response| response.into_inner())
-            .map_err(DisperseError::FailedRPC)
+            .map_err(|e| DisperseError::FailedRPC(Box::new(e)))
     }
 
     /// Returns the payment state of the disperser client
@@ -253,7 +253,7 @@ impl<S> DisperserClient<S> {
             .get_payment_state(request)
             .await
             .map(|response: tonic::Response<GetPaymentStateReply>| response.into_inner())
-            .map_err(DisperseError::FailedRPC)
+            .map_err(|e| DisperseError::FailedRPC(Box::new(e)))
     }
 
     pub async fn blob_commitment(&self, data: &[u8]) -> Result<BlobCommitmentReply, DisperseError> {
@@ -267,7 +267,7 @@ impl<S> DisperserClient<S> {
             .get_blob_commitment(request)
             .await
             .map(|response| response.into_inner())
-            .map_err(DisperseError::FailedRPC)
+            .map_err(|e| DisperseError::FailedRPC(Box::new(e)))
     }
 }
 

--- a/crates/rust-eigenda-v2-client/src/errors.rs
+++ b/crates/rust-eigenda-v2-client/src/errors.rs
@@ -14,7 +14,7 @@ pub enum EigenClientError {
     #[error(transparent)]
     Blob(#[from] BlobError),
     #[error(transparent)]
-    PayloadDisperser(#[from] PayloadDisperserError),
+    PayloadDisperser(#[from] Box<PayloadDisperserError>),
 }
 
 /// Errors specific to conversion
@@ -58,7 +58,7 @@ pub enum ConversionError {
 #[derive(Debug, thiserror::Error)]
 pub enum RelayPayloadRetrieverError {
     #[error(transparent)]
-    RelayClient(#[from] RelayClientError),
+    RelayClient(#[from] Box<RelayClientError>),
     #[error(transparent)]
     Blob(#[from] BlobError),
     #[error(transparent)]
@@ -120,6 +120,12 @@ pub enum RelayClientError {
     RelayKeyToUrl(u32),
 }
 
+impl From<RelayClientError> for RelayPayloadRetrieverError {
+    fn from(err: RelayClientError) -> Self {
+        RelayPayloadRetrieverError::RelayClient(Box::new(err))
+    }
+}
+
 /// Errors for the EthClient
 #[derive(Debug, thiserror::Error)]
 pub enum EthClientError {
@@ -166,7 +172,7 @@ pub enum DisperseError {
     #[error("Invalid Account id")]
     AccountID,
     #[error("Failed RPC call: {0}")]
-    FailedRPC(#[from] tonic::Status),
+    FailedRPC(#[from] Box<tonic::Status>),
     #[error("Calculated and disperser blob key mismatch")]
     BlobKeyMismatch,
     #[error(transparent)]
@@ -175,6 +181,12 @@ pub enum DisperseError {
     SystemTime(#[from] std::time::SystemTimeError),
     #[error(transparent)]
     Signer(#[from] Box<dyn std::error::Error + Send + Sync>),
+}
+
+impl From<tonic::Status> for DisperseError {
+    fn from(err: tonic::Status) -> Self {
+        DisperseError::FailedRPC(Box::new(err))
+    }
 }
 
 /// Errors specific to the [`PayloadDisperser`].
@@ -190,6 +202,12 @@ pub enum PayloadDisperserError {
     Decode(#[from] DecodeError),
     #[error(transparent)]
     CertVerifier(#[from] CertVerifierError),
+}
+
+impl From<PayloadDisperserError> for EigenClientError {
+    fn from(err: PayloadDisperserError) -> Self {
+        EigenClientError::PayloadDisperser(Box::new(err))
+    }
 }
 
 /// Errors specific to the CertVerifier

--- a/crates/rust-eigenda-v2-client/src/payload_disperser.rs
+++ b/crates/rust-eigenda-v2-client/src/payload_disperser.rs
@@ -101,10 +101,13 @@ impl<S> PayloadDisperser<S> {
             .disperser_client
             .blob_status(blob_key)
             .await
-            .map_err(|e| EigenClientError::PayloadDisperser(PayloadDisperserError::Disperser(e)))?;
+            .map_err(|e| {
+                EigenClientError::PayloadDisperser(Box::new(PayloadDisperserError::Disperser(e)))
+            })?;
 
-        let blob_status = BlobStatus::try_from(status.status)
-            .map_err(|e| EigenClientError::PayloadDisperser(PayloadDisperserError::Decode(e)))?;
+        let blob_status = BlobStatus::try_from(status.status).map_err(|e| {
+            EigenClientError::PayloadDisperser(Box::new(PayloadDisperserError::Decode(e)))
+        })?;
         match blob_status {
             BlobStatus::Unknown | BlobStatus::Failed => Err(PayloadDisperserError::BlobStatus)?,
             BlobStatus::Encoded | BlobStatus::GatheringSignatures | BlobStatus::Queued => Ok(None),
@@ -114,7 +117,9 @@ impl<S> PayloadDisperser<S> {
                     .verify_cert_v2(&eigenda_cert)
                     .await
                     .map_err(|e| {
-                        EigenClientError::PayloadDisperser(PayloadDisperserError::CertVerifier(e))
+                        EigenClientError::PayloadDisperser(Box::new(
+                            PayloadDisperserError::CertVerifier(e),
+                        ))
                     })?;
                 Ok(Some(eigenda_cert))
             }
@@ -132,11 +137,11 @@ impl<S> PayloadDisperser<S> {
         let signed_batch = match status.clone().signed_batch {
             Some(batch) => batch,
             None => {
-                return Err(EigenClientError::PayloadDisperser(
+                return Err(EigenClientError::PayloadDisperser(Box::new(
                     PayloadDisperserError::Conversion(ConversionError::SignedBatch(
                         "Not Present".to_string(),
                     )),
-                ))
+                )))
             }
         };
         let non_signer_stakes_and_signature = self
@@ -144,7 +149,7 @@ impl<S> PayloadDisperser<S> {
             .get_non_signer_stakes_and_signature(signed_batch)
             .await
             .map_err(|e| {
-                EigenClientError::PayloadDisperser(PayloadDisperserError::CertVerifier(e))
+                EigenClientError::PayloadDisperser(Box::new(PayloadDisperserError::CertVerifier(e)))
             })?;
 
         let cert = build_cert_from_reply(status, non_signer_stakes_and_signature)?;

--- a/crates/rust-eigenda-v2-client/src/payload_disperser.rs
+++ b/crates/rust-eigenda-v2-client/src/payload_disperser.rs
@@ -27,7 +27,6 @@ pub struct PayloadDisperser<S = PrivateKeySigner> {
     config: PayloadDisperserConfig,
     disperser_client: DisperserClient<S>,
     cert_verifier: CertVerifier<S>,
-    required_quorums: Vec<u8>,
 }
 
 impl<S> PayloadDisperser<S> {
@@ -51,12 +50,10 @@ impl<S> PayloadDisperser<S> {
             payload_config.eth_rpc_url.clone(),
             signer,
         )?;
-        let required_quorums = cert_verifier.quorum_numbers_required().await?;
         Ok(PayloadDisperser {
             disperser_client,
             config: payload_config.clone(),
             cert_verifier,
-            required_quorums,
         })
     }
 
@@ -69,12 +66,13 @@ impl<S> PayloadDisperser<S> {
             .to_blob(self.config.polynomial_form)
             .map_err(ConversionError::EigenDACommon)?;
 
+        let required_quorums = self.cert_verifier.quorum_numbers_required().await?;
         let (blob_status, blob_key) = self
             .disperser_client
             .disperse_blob(
                 &blob.serialize(),
                 self.config.blob_version,
-                &self.required_quorums,
+                &required_quorums,
             )
             .await?;
 


### PR DESCRIPTION
The rust client retrieved the required quorums only once when it was initialized, it should check the required quorums each time a new payload is sent like the [go client does](https://github.com/Layr-Labs/eigenda/blob/4d1994e318ff6898cfd500270d8881e18dc021bf/api/clients/v2/payloaddispersal/payload_disperser.go#L105-L106).