### PR TITLE
Revert config

### DIFF
--- a/crates/rust-eigenda-v2-client/Cargo.toml
+++ b/crates/rust-eigenda-v2-client/Cargo.toml
@@ -16,7 +16,7 @@ exclude = [
 
 [dependencies]
 rust-eigenda-signers = { version = "0.1.6" }
-rust-eigenda-v2-common = "0.1.4"
+rust-eigenda-v2-common = "=0.1.3"
 
 rand = { workspace = true }
 bytes = { workspace = true }

--- a/crates/rust-eigenda-v2-client/src/lib.rs
+++ b/crates/rust-eigenda-v2-client/src/lib.rs
@@ -75,7 +75,7 @@ pub(crate) mod generated {
 mod tests {
     use alloy::primitives::Address;
     use dotenv::dotenv;
-    use rust_eigenda_v2_common::{EigenDACert, Payload};
+    use rust_eigenda_v2_common::{EigenDACert, Payload, PayloadForm};
     use std::{env, str::FromStr, time::Duration};
     use url::Url;
 
@@ -109,10 +109,12 @@ mod tests {
 
     fn get_test_payload_disperser_config() -> PayloadDisperserConfig {
         PayloadDisperserConfig {
+            polynomial_form: PayloadForm::Coeff,
             blob_version: 0,
             cert_verifier_router_address: CERT_VERIFIER_ROUTER_ADDRESS.to_string(),
             eth_rpc_url: get_test_holesky_rpc_url(),
             disperser_rpc: HOLESKY_DISPERSER_RPC_URL.to_string(),
+            use_secure_grpc_flag: false,
             registry_coordinator_addr: REGISTRY_COORDINATOR_ADDRESS.to_string(),
             operator_state_retriever_addr: OPERATOR_STATE_RETRIEVER_ADDRESS.to_string(),
         }
@@ -120,6 +122,7 @@ mod tests {
 
     pub fn get_relay_payload_retriever_test_config() -> RelayPayloadRetrieverConfig {
         RelayPayloadRetrieverConfig {
+            payload_form: PayloadForm::Coeff,
             retrieval_timeout_secs: Duration::from_secs(10),
         }
     }

--- a/crates/rust-eigenda-v2-client/src/payload_disperser.rs
+++ b/crates/rust-eigenda-v2-client/src/payload_disperser.rs
@@ -5,7 +5,7 @@ use ark_bn254::G1Affine;
 use ark_ff::{BigInteger, PrimeField};
 use eigensdk::client_avsregistry::reader::{AvsRegistryChainReader, AvsRegistryReader};
 use rust_eigenda_v2_common::{
-    BatchHeaderV2, EigenDACert, NonSignerStakesAndSignature, Payload, SignedBatch,
+    BatchHeaderV2, EigenDACert, NonSignerStakesAndSignature, Payload, PayloadForm, SignedBatch,
 };
 use tiny_keccak::{Hasher, Keccak};
 
@@ -55,10 +55,12 @@ impl TryFrom<SignedBatchProto> for SignedBatch {
 
 #[derive(Clone, Debug)]
 pub struct PayloadDisperserConfig {
+    pub polynomial_form: PayloadForm,
     pub blob_version: u16,
     pub cert_verifier_router_address: String,
     pub eth_rpc_url: SecretUrl,
     pub disperser_rpc: String,
+    pub use_secure_grpc_flag: bool,
     pub registry_coordinator_addr: String,
     pub operator_state_retriever_addr: String,
 }
@@ -84,6 +86,7 @@ impl<S> PayloadDisperser<S> {
         let disperser_config = DisperserClientConfig {
             disperser_rpc: payload_config.disperser_rpc.clone(),
             signer: signer.clone(),
+            use_secure_grpc_flag: payload_config.use_secure_grpc_flag,
         };
         let disperser_client = DisperserClient::new(disperser_config).await?;
         let cert_verifier = CertVerifier::new(
@@ -104,7 +107,9 @@ impl<S> PayloadDisperser<S> {
     where
         S: Sign,
     {
-        let blob = payload.to_blob().map_err(ConversionError::EigenDACommon)?;
+        let blob = payload
+            .to_blob(self.config.polynomial_form)
+            .map_err(ConversionError::EigenDACommon)?;
 
         let required_quorums = self.cert_verifier.quorum_numbers_required().await?;
         let (blob_status, blob_key) = self
@@ -391,7 +396,7 @@ impl<S> PayloadDisperser<S> {
 
 #[cfg(test)]
 mod tests {
-    use rust_eigenda_v2_common::Payload;
+    use rust_eigenda_v2_common::{Payload, PayloadForm};
 
     use crate::{
         payload_disperser::{PayloadDisperser, PayloadDisperserConfig},
@@ -408,10 +413,12 @@ mod tests {
         let timeout = tokio::time::Duration::from_secs(180);
 
         let payload_config = PayloadDisperserConfig {
+            polynomial_form: PayloadForm::Coeff,
             blob_version: 0,
             cert_verifier_router_address: CERT_VERIFIER_ROUTER_ADDRESS.to_string(),
             eth_rpc_url: get_test_holesky_rpc_url(),
             disperser_rpc: HOLESKY_DISPERSER_RPC_URL.to_string(),
+            use_secure_grpc_flag: false,
             registry_coordinator_addr: REGISTRY_COORDINATOR_ADDRESS.to_string(),
             operator_state_retriever_addr: OPERATOR_STATE_RETRIEVER_ADDRESS.to_string(),
         };

--- a/crates/rust-eigenda-v2-client/src/relay_payload_retriever.rs
+++ b/crates/rust-eigenda-v2-client/src/relay_payload_retriever.rs
@@ -1,7 +1,7 @@
 use std::time::Duration;
 
 use rand::seq::SliceRandom;
-use rust_eigenda_v2_common::{Blob, EigenDACert, Payload};
+use rust_eigenda_v2_common::{Blob, EigenDACert, Payload, PayloadForm};
 use rust_kzg_bn254_prover::srs::SRS;
 use tokio::time::timeout;
 
@@ -32,6 +32,7 @@ pub struct SRSConfig {
 
 #[derive(Clone)]
 pub struct RelayPayloadRetrieverConfig {
+    pub payload_form: PayloadForm,
     pub retrieval_timeout_secs: Duration,
 }
 
@@ -134,11 +135,11 @@ impl RelayPayloadRetriever {
                 continue;
             }
 
-            let payload = match blob.to_payload() {
+            let payload = match blob.to_payload(self.config.payload_form) {
                 Ok(payload) => payload,
                 Err(err) => {
                     println!(
-                        "Error converting blob retrieved from relay {relay_key} to payload: {err}"
+                        "Error converting blob retrieved from relay {relay_key} to payload: {err}",
                     );
                     continue;
                 }

--- a/crates/rust-eigenda-v2-common/src/core.rs
+++ b/crates/rust-eigenda-v2-common/src/core.rs
@@ -15,3 +15,12 @@ pub(crate) const BYTES_PER_SYMBOL: usize = 32;
 pub enum PayloadEncodingVersion {
     Zero = 0,
 }
+
+/// The form of a payload dictates what conversion, if any, must be performed when creating a blob from the payload.
+#[derive(Clone, Copy, Debug)]
+pub enum PayloadForm {
+    /// Evaluation form, where the payload is in evaluation form.
+    Eval,
+    /// Coefficient form, where the payload is in coefficient form.
+    Coeff,
+}

--- a/crates/rust-eigenda-v2-common/src/core/blob.rs
+++ b/crates/rust-eigenda-v2-common/src/core/blob.rs
@@ -1,7 +1,8 @@
 use ark_bn254::Fr;
 
-use crate::core::{EncodedPayload, Payload, BYTES_PER_SYMBOL};
+use crate::core::{EncodedPayload, Payload, PayloadForm, BYTES_PER_SYMBOL};
 use crate::errors::BlobError;
+use crate::utils::coeff_to_eval_poly;
 
 /// [`Blob`] is data that is dispersed on EigenDA.
 ///
@@ -48,8 +49,11 @@ impl Blob {
     }
 
     /// Converts the [`Blob`] into a [`Payload`].
-    pub fn to_payload(&self) -> Result<Payload, BlobError> {
-        let encoded_payload = self.to_encoded_payload()?;
+    ///
+    /// The payload_form indicates how payloads are interpreted. The way that payloads are interpreted dictates what
+    /// conversion, if any, must be performed when creating a payload from the blob.
+    pub fn to_payload(&self, payload_form: PayloadForm) -> Result<Payload, BlobError> {
+        let encoded_payload = self.to_encoded_payload(payload_form)?;
         let payload = encoded_payload.decode()?;
         Ok(payload)
     }
@@ -85,8 +89,19 @@ impl Blob {
     }
 
     /// Creates an [`EncodedPayload`] from the blob.
-    pub fn to_encoded_payload(&self) -> Result<EncodedPayload, BlobError> {
-        let payload_elements = self.coeff_polynomial.clone();
+    ///
+    /// The payload_form indicates how payloads are interpreted. The way that payloads are interpreted dictates what
+    /// conversion, if any, must be performed when creating an encoded payload from the blob.
+    pub fn to_encoded_payload(
+        &self,
+        payload_form: PayloadForm,
+    ) -> Result<EncodedPayload, BlobError> {
+        let payload_elements = match payload_form {
+            PayloadForm::Coeff => self.coeff_polynomial.clone(),
+            PayloadForm::Eval => {
+                coeff_to_eval_poly(self.coeff_polynomial.clone(), self.blob_length_symbols)?
+            }
+        };
 
         let max_possible_payload_length =
             self.get_max_permissible_payloadlength(self.blob_length_symbols)?;
@@ -101,16 +116,18 @@ impl Blob {
 mod tests {
     use proptest::prelude::*;
 
-    use crate::core::{blob::Blob, payload::Payload};
+    use crate::core::{blob::Blob, payload::Payload, PayloadForm};
 
-    fn blob_conversion_for_form(payload_bytes: Vec<u8>) {
-        let blob: Blob = Payload::new(payload_bytes.clone()).to_blob().unwrap();
+    fn blob_conversion_for_form(payload_bytes: Vec<u8>, payload_form: PayloadForm) {
+        let blob: Blob = Payload::new(payload_bytes.clone())
+            .to_blob(payload_form)
+            .unwrap();
         let blob_deserialized =
             Blob::deserialize_blob(blob.serialize(), blob.blob_length_symbols).unwrap();
 
-        let payload_from_blob = blob.to_payload().unwrap();
+        let payload_from_blob = blob.to_payload(payload_form).unwrap();
 
-        let payload_from_deserialized_blob = blob_deserialized.to_payload().unwrap();
+        let payload_from_deserialized_blob = blob_deserialized.to_payload(payload_form).unwrap();
 
         assert_eq!(
             payload_from_blob.serialize(),
@@ -120,7 +137,8 @@ mod tests {
     }
 
     fn test_blob_conversion(original_data: &[u8]) {
-        blob_conversion_for_form(original_data.to_vec());
+        blob_conversion_for_form(original_data.to_vec(), PayloadForm::Coeff);
+        blob_conversion_for_form(original_data.to_vec(), PayloadForm::Eval);
     }
 
     proptest! {

--- a/crates/rust-eigenda-v2-common/src/core/payload.rs
+++ b/crates/rust-eigenda-v2-common/src/core/payload.rs
@@ -1,5 +1,6 @@
-use crate::core::Blob;
+use crate::core::{Blob, PayloadForm};
 use crate::errors::ConversionError;
+use crate::utils::eval_to_coeff_poly;
 
 use super::encoded_payload::EncodedPayload;
 
@@ -16,14 +17,30 @@ impl Payload {
     }
 
     /// Converts the [`Payload`] bytes into a [`Blob`].
-    pub fn to_blob(&self) -> Result<Blob, ConversionError> {
+    ///
+    /// The `payload_form` indicates how payloads are interpreted. The form of a payload dictates what conversion, if any, must
+    /// be performed when creating a blob from the payload.
+    pub fn to_blob(&self, payload_form: PayloadForm) -> Result<Blob, ConversionError> {
         let encoded_payload = EncodedPayload::new(self)?;
         let field_elements = encoded_payload.to_field_elements();
 
         let blob_length_symbols = field_elements.len().next_power_of_two();
 
+        let coeff_polynomial = match payload_form {
+            PayloadForm::Coeff => {
+                // the payload is already in coefficient form. no conversion needs to take place, since blobs are also in
+                // coefficient form
+                field_elements
+            }
+            PayloadForm::Eval => {
+                // the payload is in evaluation form, so we need to convert it to coeff form, since blobs are in coefficient form
+                let eval_poly = field_elements;
+                eval_to_coeff_poly(eval_poly, blob_length_symbols)?
+            }
+        };
+
         Ok(Blob {
-            coeff_polynomial: field_elements,
+            coeff_polynomial,
             blob_length_symbols,
         })
     }

--- a/crates/rust-eigenda-v2-common/src/lib.rs
+++ b/crates/rust-eigenda-v2-common/src/lib.rs
@@ -3,7 +3,7 @@ mod eigenda_cert;
 mod errors;
 mod utils;
 
-pub use core::{Blob, CheckDACertStatus, EncodedPayload, Payload};
+pub use core::{Blob, CheckDACertStatus, EncodedPayload, Payload, PayloadForm};
 pub use eigenda_cert::*;
 pub use errors::*;
 pub use utils::*;

--- a/crates/rust-eigenda-v2-common/src/utils.rs
+++ b/crates/rust-eigenda-v2-common/src/utils.rs
@@ -1,5 +1,6 @@
-use ark_bn254::{G1Affine, G2Affine};
+use ark_bn254::{Fr, G1Affine, G2Affine};
 use ark_ff::{AdditiveGroup, Fp, Fp2, PrimeField, Zero};
+use ark_poly::{EvaluationDomain, GeneralEvaluationDomain};
 use ark_serialize::CanonicalSerialize;
 use rust_kzg_bn254_primitives::helpers::{lexicographically_largest, read_g1_point_from_bytes_be};
 
@@ -124,4 +125,29 @@ pub fn g2_commitment_to_bytes(point: &G2Affine) -> Result<Vec<u8>, ConversionErr
 
     bytes[0] |= mask;
     Ok(bytes)
+}
+
+/// coeff_to_eval_poly converts a polynomial in coefficient form to one in evaluation form, using the FFT operation.
+pub(crate) fn coeff_to_eval_poly(
+    coeff_poly: Vec<Fr>,
+    blob_length_symbols: usize,
+) -> Result<Vec<Fr>, ConversionError> {
+    let evals = GeneralEvaluationDomain::<Fr>::new(blob_length_symbols)
+        .ok_or(ConversionError::Poly(
+            "Failed to construct domain for FFT".to_string(),
+        ))?
+        .fft(&coeff_poly);
+    Ok(evals)
+}
+
+/// Converts an eval_poly to a coeff_poly, using the IFFT operation
+///
+/// blob_length_symbols is required, to be able to choose the correct parameters when performing FFT
+pub(crate) fn eval_to_coeff_poly(
+    eval_poly: Vec<Fr>,
+    blob_length_symbols: usize,
+) -> Result<Vec<Fr>, ConversionError> {
+    Ok(GeneralEvaluationDomain::<Fr>::new(blob_length_symbols)
+        .ok_or(ConversionError::Poly("Failed to create domain".to_string()))?
+        .ifft(&eval_poly))
 }


### PR DESCRIPTION
Revert the config changes made (removing `payloadForm` and `use_secure_grpc_flag`)
Since those changes were only needed for zksync and not for the whole client